### PR TITLE
URL Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # biospecimen
 
-[![Join the chat at https://gitter.im/episphere/biospecimen](https://badges.gitter.im/episphere/biospecimen.svg)](https://gitter.im/episphere/biospecimen?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+Connect 4 Cancer Bio-Specimen Dashboard.
 
-Connect bio-specimen dashboard.
-
-### Live @ https://episphere.github.io/biospecimen/
+### Live @ https://NCI-C4CP.github.io/biospecimen/


### PR DESCRIPTION
Removing references to `episphere` after repository move to `NCI-C4CP`