### PR TITLE
Issue#1129 second collection same timepoint message

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,17 @@
                     </div>
                 </div>
             </div>
-           <div class="modal fade" id="modalShowMoreData" data-keyboard="false" tabindex="-1" role="dialog" data-backdrop="static" aria-hidden="true">
+            <!-- TEMPORARY MODAL: Replace this with unified modal system -->
+            <div class="modal fade" id="biospecimenModalExtra" data-keyboard="false" data-backdrop="static" tabindex="-1" role="dialog" aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered" role="document">
+                    <div class="modal-content sub-div-shadow">
+                        <div class="modal-header" id="biospecimenModalExtraHeader"></div>
+                        <div class="modal-body" id="biospecimenModalBodyExtraBody"></div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="modal fade" id="modalShowMoreData" data-keyboard="false" tabindex="-1" role="dialog" data-backdrop="static" aria-hidden="true">
                 <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
                     <div class="modal-content sub-div-shadow">
                         <div class="modal-header" id="modalHeader"></div>

--- a/index.html
+++ b/index.html
@@ -64,7 +64,6 @@
                     </div>
                 </div>
             </div>
-            <!-- TEMPORARY MODAL: Replace this with unified modal system -->
             <div class="modal fade" id="biospecimenModalExtra" data-keyboard="false" data-backdrop="static" tabindex="-1" role="dialog" aria-hidden="true">
                 <div class="modal-dialog modal-dialog-centered" role="document">
                     <div class="modal-content sub-div-shadow">
@@ -73,7 +72,14 @@
                     </div>
                 </div>
             </div>
-
+            <div class="modal fade" id="biospecimenCollected" data-keyboard="false" data-backdrop="static" tabindex="-1" role="dialog" aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered" role="document">
+                    <div class="modal-content sub-div-shadow">
+                        <div class="modal-header" id="biospecimenModalHeaderCollected"></div>
+                        <div class="modal-body" id="biospecimenModalBodyCollected"></div>
+                    </div>
+                </div>
+            </div>
             <div class="modal fade" id="modalShowMoreData" data-keyboard="false" tabindex="-1" role="dialog" data-backdrop="static" aria-hidden="true">
                 <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
                     <div class="modal-content sub-div-shadow">

--- a/src/events.js
+++ b/src/events.js
@@ -2834,7 +2834,7 @@ const displayClinicalSpecimenCollectedModal = (modalContext, isBloodCollected, i
     <br />
     <div style="display:inline-block; margin-top:20px;">
         <button type="button" class="btn btn-primary" data-dismiss="modal" target="_blank" id="yesTrigger">Yes</button>
-        <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank" id="noTrigger">NO</button>
+        <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank" id="noTrigger">No</button>
         </div>
     </div>`;
 
@@ -2906,7 +2906,7 @@ const displayResearchSpecimenCollectedModal = async (participantData) => {
         <br />
         <div style="display:inline-block; margin-top:20px;">
             <button type="button" class="btn btn-primary" data-dismiss="modal" target="_blank" data-toggle="modal" id="yesTrigger_Modal2">Yes</button>
-            <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank" id="noTrigger_Modal2">NO</button>
+            <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank" id="noTrigger_Modal2">No</button>
             </div>
         </div>`;
     body.innerHTML = template;
@@ -2958,7 +2958,7 @@ const displayClinicalSpecimenMissingModal = (modalData) => {
         <br />
         <div style="display:inline-block; margin-top:20px;">
             <button type="button" class="btn btn-primary" data-dismiss="modal" target="_blank" data-toggle="modal" id="yesTrigger_Modal2">Yes</button>
-            <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank" id="noTrigger_Modal2">NO</button>
+            <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank" id="noTrigger_Modal2">No</button>
             </div>
         </div>`;
     body.innerHTML = template;

--- a/src/events.js
+++ b/src/events.js
@@ -922,7 +922,7 @@ const clinicalBtnsClicked = async (participantData, formData) => {
         && !accessionID2.classList.contains('disabled')
     ) {
         hasError = true;
-        errorMessage('accessionID2', 'Please re-type Blood Accession ID from tube.', focus, true);
+        errorMessage('accessionID2', 'Please re-enter Blood Accession ID from tube.', focus, true);
         focus = false;
     } else if (
         accessionID2 
@@ -952,7 +952,7 @@ const clinicalBtnsClicked = async (participantData, formData) => {
         && !accessionID4.classList.contains('disabled')
     ) {
         hasError = true;
-        errorMessage('accessionID4', 'Please re-type Urine Accession ID from tube.', focus, true);
+        errorMessage('accessionID4', 'Please re-enter Urine Accession ID from tube.', focus, true);
         focus = false;
     } else if (
         accessionID3 
@@ -2989,6 +2989,7 @@ export const checkAccessionMatch = () => {
         
     accessionId2.addEventListener('blur', () => { 
         if (accessionId1.value !== accessionId2.value) {
+            console.log('BLUR input 2')
             errorMessage('accessionID2', 'Blood Accession ID doesn\'t match', focus, true);
         } else {
             removeSingleError('accessionID2')
@@ -2997,6 +2998,7 @@ export const checkAccessionMatch = () => {
     });
 
     accessionId4.addEventListener('blur', () => {
+        console.log('BLUR input 4')
         if (accessionId4.value !== accessionId3.value) {
             errorMessage('accessionID4', 'Urine Accession ID doesn\'t match', focus, true);
         } else {
@@ -3007,6 +3009,7 @@ export const checkAccessionMatch = () => {
 
     // add blur event handler logic the accession Id inputs for 1 and 2, when user retypes blood or urine (not re-enter input fields)
     accessionId1.addEventListener('blur', () => {
+        console.log('BLUR input 1')
         if (accessionId1.value === accessionId2.value) {
             removeSingleError('accessionID1')
             removeSingleError('accessionID2')
@@ -3022,6 +3025,7 @@ export const checkAccessionMatch = () => {
     });
 
     accessionId3.addEventListener('blur', () => {
+        console.log('BLUR input 3')
         if (accessionId3.value === accessionId4.value) {
             removeSingleError('accessionID3')
             removeSingleError('accessionID4')

--- a/src/events.js
+++ b/src/events.js
@@ -2989,7 +2989,6 @@ export const checkAccessionMatch = () => {
         
     accessionId2.addEventListener('blur', () => { 
         if (accessionId1.value !== accessionId2.value) {
-            console.log('BLUR input 2')
             errorMessage('accessionID2', 'Blood Accession ID doesn\'t match', focus, true);
         } else {
             removeSingleError('accessionID2')
@@ -2998,7 +2997,6 @@ export const checkAccessionMatch = () => {
     });
 
     accessionId4.addEventListener('blur', () => {
-        console.log('BLUR input 4')
         if (accessionId4.value !== accessionId3.value) {
             errorMessage('accessionID4', 'Urine Accession ID doesn\'t match', focus, true);
         } else {
@@ -3009,7 +3007,6 @@ export const checkAccessionMatch = () => {
 
     // add blur event handler logic the accession Id inputs for 1 and 2, when user retypes blood or urine (not re-enter input fields)
     accessionId1.addEventListener('blur', () => {
-        console.log('BLUR input 1')
         if (accessionId1.value === accessionId2.value) {
             removeSingleError('accessionID1')
             removeSingleError('accessionID2')
@@ -3025,7 +3022,6 @@ export const checkAccessionMatch = () => {
     });
 
     accessionId3.addEventListener('blur', () => {
-        console.log('BLUR input 3')
         if (accessionId3.value === accessionId4.value) {
             removeSingleError('accessionID3')
             removeSingleError('accessionID4')

--- a/src/events.js
+++ b/src/events.js
@@ -3005,7 +3005,7 @@ export const checkAccessionMatch = () => {
         }
     });
 
-    // add blur event handler logic the accession Id inputs for 1 and 2, when user retypes bloor or urine (not reenter input fields)
+    // add blur event handler logic the accession Id inputs for 1 and 2, when user retypes blood or urine (not re-enter input fields)
     accessionId1.addEventListener('blur', () => {
         if (accessionId1.value === accessionId2.value) {
             removeSingleError('accessionID1')

--- a/src/events.js
+++ b/src/events.js
@@ -892,6 +892,8 @@ console.log("🚀 ~ clinicalBtnsClicked ~ formData:", formData)
     const accessionID3 = document.getElementById('accessionID3');
     const accessionID4 = document.getElementById('accessionID4');
     const selectedVisit = document.getElementById('visit-select').value;
+    // needed to find if specimens are collected for specific visit
+    
     
     let hasError = false;
     let focus = true;
@@ -970,101 +972,55 @@ console.log("🚀 ~ clinicalBtnsClicked ~ formData:", formData)
 
     if (hasError) return;
     // error checking for any missing input fields
+    const isBloodCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.bloodCollectionSetting] === conceptIds.clinical; 
+    console.log("🚀 ~ clinicalBtnsClicked ~ conceptIds.bloodCollectionSetting:", conceptIds.bloodCollectionSetting)
+    console.log("🚀 ~ clinicalBtnsClicked ~ isBloodCollected:", isBloodCollected)
+    const isUrineCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.urineCollectionSetting] === conceptIds.clinical;
+    console.log("🚀 ~ clinicalBtnsClicked ~ conceptIds.urineCollectionSetting:", conceptIds.urineCollectionSetting)
+    console.log("🚀 ~ clinicalBtnsClicked ~ isUrineCollected:", isUrineCollected)
 
-
-    let confirmVal = 'No';
+    // let confirmVal = 'No';
     // clinicalSpecimensCollectedModal(participantData, conceptIds.bloodCollectionSetting, conceptIds.urineCollectionSetting);
 
     if (!hasError && accessionID2.value && accessionID4.value) { // both inputs added
-        const modalData = await clinicalSpecimensCollectedModal(modalContext, conceptIds.bloodCollectionSetting, conceptIds.urineCollectionSetting);
-        triggerConfirmationModal(modalData); // this will trigger the confirmation modal
+        const collectedModalData = await displayClinicalSpecimenCollectedModal(modalContext, isBloodCollected, isUrineCollected);
+        if (!collectedModalData) return; // if user clicked no on the modal
+        console.log("🚀 ~ clinicalBtnsClicked ~ modalData:", collectedModalData)
+        triggerConfirmationModal(collectedModalData); // this will trigger the confirmation modal
     } else if (accessionID1 && accessionID1.value && accessionID3 && !accessionID3.value) { // For only blood accession id inputs
         // this can be refactored to a function
-        console.log("test this output! else if")
+        const confirmCollectedData = await displayClinicalSpecimenCollectedModal(modalContext, isBloodCollected, isUrineCollected);
+        console.log("🚀 ~ clinicalBtnsClicked ~ confirmCollectedData:", confirmCollectedData)
+        if (!confirmCollectedData) return; // if user clicked no on the modal
+        const missingModalData = await displayClinicalSpecimenMissingModal(confirmCollectedData);
+        console.log("🚀 ~ clinicalBtnsClicked ~ missingModalData:", typeof missingModalData)
+        if (!missingModalData) return; // if user clicked no on the modal
 
-
-        const button = document.createElement('button');
-        button.dataset.target = '#biospecimenModal';
-        button.dataset.toggle = 'modal';
-    
-        document.getElementById('root').appendChild(button);
-        button.click();
-        document.getElementById('root').removeChild(button);
-        const header = document.getElementById('biospecimenModalHeader');
-        const body = document.getElementById('biospecimenModalBody');
-        header.innerHTML = `Urine Accession Id is Missing`
-        let template =  `You have not entered a Urine Accession Id. Do you want to continue?`
-        template += `
-        <br />
-        <div style="display:inline-block; margin-top:20px;">
-            <button type="button" class="btn btn-primary" data-dismiss="modal" target="_blank"  data-toggle="modal" id="yesTrigger">Yes</button>
-            <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank" id="noTrigger">NO</button>
-            </div>
-        </div>`
-        body.innerHTML = template;
-
-
-        const noBtn = document.getElementById('noTrigger')
-        noBtn.addEventListener("click", async e => {
-            confirmVal = 'No'
-        })
-
-        const yesBtn = document.getElementById('yesTrigger')
-        yesBtn.addEventListener("click", async e => {
-            confirmVal = 'Yes'
-            triggerConfirmationModal(accessionID2, accessionID4, participantName, hasError, confirmVal, selectedVisit, formData, connectId)
-        })
+        console.log("missingModalData!!!!!!", missingModalData)
+        // if (missingModalData?.confirmVal === 'No') return; // user clicked no on the modal
+        triggerConfirmationModal(missingModalData); // this will trigger the confirmation modal
 
     } else if (accessionID1 && !accessionID1.value && accessionID3 && accessionID3.value) { // For only urine accession id inputs
-        const button = document.createElement('button');
-        button.dataset.target = '#biospecimenModal';
-        button.dataset.toggle = 'modal';
-    
-        document.getElementById('root').appendChild(button);
-        button.click();
-        document.getElementById('root').removeChild(button);
-        const header = document.getElementById('biospecimenModalHeader');
-        const body = document.getElementById('biospecimenModalBody');
-        header.innerHTML = `Blood Accession Id is Missing`
-        let template =  `You have not entered a Blood Accession Id. Do you want to continue?`
-        template += `
-        <br />
-        <div style="display:inline-block; margin-top:20px;">
-            <button type="button" class="btn btn-primary" data-dismiss="modal" target="_blank" id="yesTrigger">Yes</button>
-            <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank" id="noTrigger">NO</button>
-            </div>
-        </div>`
-        body.innerHTML = template;
+        const confirmCollectedData = await displayClinicalSpecimenCollectedModal(modalContext, isBloodCollected, isUrineCollected);
+        console.log("🚀 ~ clinicalBtnsClicked ~ confirmCollectedData:", confirmCollectedData)
+        if (!confirmCollectedData) return; // if user clicked no on the modal
+        const missingModalData = await displayClinicalSpecimenMissingModal(confirmCollectedData);
+        console.log("🚀 ~ clinicalBtnsClicked ~ missingModalData:", typeof missingModalData)
+        if (!missingModalData) return; // if user clicked no on the modal
 
-        const noBtn = document.getElementById('noTrigger')
-        noBtn.addEventListener("click", async e => {
-            confirmVal = 'No'
-        })
-
-        const yesBtn = document.getElementById('yesTrigger')
-        yesBtn.addEventListener("click", async e => {
-            confirmVal = 'Yes'
-            triggerConfirmationModal(accessionID2, accessionID4, participantName, hasError, confirmVal, selectedVisit, formData, connectId) // confirmation modal 
-        })
+        console.log("missingModalData!!!!!!", missingModalData)
+        // if (missingModalData?.confirmVal === 'No') return; // user clicked no on the modal
+        triggerConfirmationModal(missingModalData); // 
     }
 
 }; // End of ClinicalBtnsClicked ********
 
-// Can add confirmation modal inside
-// proceedToSpecimenPage or redirectSpecimenPage
-const triggerConfirmationModal =  (modalData) => {
-    const { confirmVal } = modalData; 
-    const hasError = modalData?.modalContext?.hasError;
-    if (!hasError && confirmVal === 'Yes') {
-        confirmationModal(modalData)
-    }
-}
-
-const confirmationModal = (modalData) => {
+const triggerConfirmationModal = (modalData) => {
+    console.log("modal data", modalData.context)  
     const { accessionID2, accessionID4, participantName, selectedVisit, formData, connectId } = modalData.modalContext;
-    console.log("accessionID2, accessionID4, participantName, selectedVisit, formData, connectId")
-    console.log(modalData.modalContext)
-    // return
+    console.log("invoked",modalData.modalContext)
+    console.log("🚀 ~ confirmationModal ~ modalData:", modalData)
+
     const button = document.createElement('button');
     button.dataset.target = '#modalShowMoreData';
     button.dataset.toggle = 'modal';
@@ -1115,23 +1071,10 @@ const clinicalSpecimensCollectedModal = (modalContext, bloodCollectionSetting, u
     // make into a single function that handles both, or blood, or urine
 
     // Either of these two should be clinical concept Id (664882224)
-    const isBloodCollected = participantData[conceptIds.collectionDetails][selectedVisit][bloodCollectionSetting] === conceptIds.clinical; 
-    const isUrineCollected = participantData[conceptIds.collectionDetails][selectedVisit][urineCollectionSetting] === conceptIds.clinical;
+    const isBloodCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[bloodCollectionSetting] === conceptIds.clinical; 
+    const isUrineCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[urineCollectionSetting] === conceptIds.clinical;
 
-    // console.log("isBloodCollected", isBloodCollected)
-    // console.log("isUrineCollected", isUrineCollected)
-    /*
-    Add modal here?
-    Use case switch statement to determine the message to be displayed
-    
-    
-    
-    */
-
-
-    // Add case switch statement here
-
-    return clinicalCollectedModalContent(modalContext,isBloodCollected, isUrineCollected)
+    return displayClinicalSpecimenCollectedModal(modalContext,isBloodCollected, isUrineCollected)
 
     
 }
@@ -2881,24 +2824,17 @@ const searchAvailableCollectionsForSpecimen = (specimenId) => {
     return false;
 }
 
-
-/* 
-Clinical modal template
-
-
-
-triggerConfirmationModal --> confirmation modal
+/**
+ * displays a modal to confirm if the user wants to continue with collected blood and/or urine specimens
+ * @param {object} modalContext - context object containing information about the modal
+ * @param {boolean} isBloodCollected - flag indicating if blood specimen is collected
+ * @param {boolean} isUrineCollected - flag indicating if urine specimen is collected
+ * @returns {Promise} - resolves with the modalContext if user clicks "Yes", otherwise resolves with null
 */
-const clinicalCollectedModalContent = (modalContext, isBloodCollected, isUrineCollected) => {
+
+const displayClinicalSpecimenCollectedModal = (modalContext, isBloodCollected, isUrineCollected) => {
+    console.log("isBloodCollected, isUrineCollected", isBloodCollected, isUrineCollected)
     const button = document.createElement('button');
-    let confirmVal = 'No';
-    const modalButtons = `
-    <br />
-    <div style="display:inline-block; margin-top:20px;">
-        <button type="button" class="btn btn-primary" data-dismiss="modal" target="_blank" id="yesTrigger">Yes</button>
-        <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank" id="noTrigger">NO</button>
-        </div>
-    </div>`
     button.dataset.target = '#biospecimenModal';
     button.dataset.toggle = 'modal';
     document.getElementById('root').appendChild(button);
@@ -2906,6 +2842,13 @@ const clinicalCollectedModalContent = (modalContext, isBloodCollected, isUrineCo
     document.getElementById('root').removeChild(button);
     const header = document.getElementById('biospecimenModalHeader');
     const body = document.getElementById('biospecimenModalBody');
+    const modalButtons = `
+    <br />
+    <div style="display:inline-block; margin-top:20px;">
+        <button type="button" class="btn btn-primary" data-dismiss="modal" target="_blank" id="yesTrigger">Yes</button>
+        <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank" id="noTrigger">NO</button>
+        </div>
+    </div>`;
 
     if (isBloodCollected && isUrineCollected) {
         header.innerHTML = `Blood and Urine Specimens Already Collected`
@@ -2916,33 +2859,74 @@ const clinicalCollectedModalContent = (modalContext, isBloodCollected, isUrineCo
     } else if (isUrineCollected) { 
         header.innerHTML = `Urine Specimen Already Collected`
         body.innerHTML = "This participant already has a urine specimen collected for this timepoint. Do you wish to continue?" + modalButtons
+    }
+    
+    return new Promise((resolve) => {
+        const noBtn = document.getElementById('noTrigger');
+        noBtn.addEventListener("click", () => {
+            resolve(null);
+        });
+        const yesBtn = document.getElementById('yesTrigger');
+        yesBtn.addEventListener("click", () => {
+            resolve({ modalContext });
+        });
+    })
+};
+
+// This will be called when user clicks "Yes" and there is a missing urine or blood smaple
+const displayClinicalSpecimenMissingModal = (modalData) => { 
+    
+    const { accessionID2, accessionID4, participantName, hasError, selectedVisit, formData, connectId } = modalData?.modalContext;
+    // let confirmVal = modalData?.modalContext?.confirmVal;
+    // if (modalData?.modalContext?.confirmVal === 'No') return;
+    // if (confirmVal === 'No') return;
+    console.log("accessionID2", accessionID2, "--", "accessionID2.value", accessionID2?.value)
+    console.log("accessionID4", accessionID4, "--", "accessionID4.value", accessionID4?.value)
+
+    // determine if accedsionID2 or accessionID4 is missing
+    // based on what is missing, display appropriate modal content
+
+    const button = document.createElement('button');
+    button.dataset.target = '#biospecimenModalExtra';
+    button.dataset.toggle = 'modal';
+
+    document.getElementById('root').appendChild(button);
+    button.click();
+    document.getElementById('root').removeChild(button);
+
+
+    const header = document.getElementById('biospecimenModalExtraHeader');
+    const body = document.getElementById('biospecimenModalBodyExtraBody');
+    let template;
+
+    if (accessionID2 && accessionID2.value) {
+        header.innerHTML = 'Urine Accession Id is Missing';
+        template = 'You have not entered a Urine Accession Id. Do you want to continue?';
+    } else if (accessionID4 && accessionID4.value) {
+        header.innerHTML = 'Blood Accession Id is Missing';
+        template = 'You have not entered a Blood Accession Id. Do you want to continue?';
     } else {
         return;
     }
 
-    return new Promise( (resolve) => {
-        const noBtn = document.getElementById('noTrigger');
+    template += `
+        <br />
+        <div style="display:inline-block; margin-top:20px;">
+            <button type="button" class="btn btn-primary" data-dismiss="modal" target="_blank" data-toggle="modal" id="yesTrigger_Modal2">Yes</button>
+            <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank" id="noTrigger_Modal2">NO</button>
+            </div>
+        </div>`;
+    body.innerHTML = template;
+    
+    return new Promise ((resolve) => {
+        const noBtn = document.getElementById('noTrigger_Modal2');
         noBtn.addEventListener("click", async e => {
-            confirmVal = 'No';
-            resolve({ confirmVal });
+            resolve(null);
         });
-        const yesBtn = document.getElementById('yesTrigger');
+
+        const yesBtn = document.getElementById('yesTrigger_Modal2');
         yesBtn.addEventListener("click", async e => {
-            confirmVal = 'Yes';
-            resolve({ modalContext,confirmVal });
+            resolve(modalData);
         });
     })
-
-    // const noBtn = document.getElementById('noTrigger')
-    // noBtn.addEventListener("click", async e => {
-    //     confirmVal = 'No'
-    // });
-
-    // const yesBtn = document.getElementById('yesTrigger')
-    // yesBtn.addEventListener("click", async e => {
-    //     confirmVal = 'Yes'
-    //     // triggerConfirmationModal(accessionID2, accessionID4, participantName, hasError, confirmVal, selectedVisit, formData, connectId) // confirmation modal 
-    // });
-
-
 }

--- a/src/events.js
+++ b/src/events.js
@@ -553,12 +553,9 @@ export const addGoToSpecimenLinkEvent = () => {
 };
 
 export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
-    console.log("🚀 ~ addEventCheckInCompleteForm ~ isCheckedIn:", isCheckedIn)
     const form = document.getElementById('checkInCompleteForm');
     form && form.addEventListener('submit', async e => {
         e.preventDefault();
-
-
         try {
             const btnCheckIn = document.getElementById('checkInComplete');
             
@@ -587,31 +584,20 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
                         const now = new Date();
                         if (now.getYear() == visitTime.getYear() && now.getMonth() == visitTime.getMonth() && now.getDate() == visitTime.getDate()) {
                             const response = await getParticipantCollections(data.token);
+
                             let collection = response.data.filter(res => res[conceptIds.collection.selectedVisit] == visit.concept);
                             if (collection.length === 0) continue;
+
                             const confirmContinueCheckIn = await handleCheckInWarning(visit, data, collection);
-                            console.log("🚀 ~ addEventCheckInCompleteForm ~ confirmContinueCheckIn:", confirmContinueCheckIn)
                             if (!confirmContinueCheckIn) return;
                         }
                     }
                 }
 
-                // Need to add condition to not run this if the user has no collection for a specific visit
-                console.log("!data?.[conceptIds.collectionDetails]?.visitConcept", !data?.[conceptIds.collectionDetails], "visit concept ---", visitConcept, "combined", data?.[conceptIds.collectionDetails]?.[visitConcept], "data?.[conceptIds.collectionDetails]",data?.[conceptIds.collectionDetails])
-                // if (!data?.[conceptIds.collectionDetails]?.visitConcept) {
-                // }
-                // return;
-                console.log("data", data);
-                console.log("[conceptIds.collectionDetails]", [conceptIds.collectionDetails])
-                console.log("visitConcept", visitConcept)
-                // console.log("data?.[conceptIds.collectionDetails]", data?.[conceptIds.collectionDetails])
-                console.log("data?.[conceptIds.collectionDetails]?.visitConcept", data?.[conceptIds.collectionDetails]?.[visitConcept])
-                if (data?.[conceptIds.collectionDetails]?.[visitConcept]) { // This function will run if there is a collection for a selected visit
+                if (data?.[conceptIds.collectionDetails]?.[visitConcept]) { // This function will run if there is a pre-existing collection for the selected visit
                     const confirmCollectedModal = await displayResearchSpecimenCollectedModal(data);
-                    console.log("🚀 ~ addEventCheckInCompleteForm ~ confirmCollectedModal:", confirmCollectedModal)
                     if (!confirmCollectedModal) return;
                 }
-                // return;
 
                 await handleCheckInModal(data, visitConcept, query); 
                 btnCheckIn.disabled = true;
@@ -627,7 +613,7 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
  * Checks if the participant has any specimen collected (clinical blood or clinical urine) under baseline from the dashboard or collected clinical blood or urine derivations from the site EMR API. If participant has either a clinical blood or urine dashboard variable or other blood/urine derived variables from the site EMR API, show a notification and return true.
  * @param {Object} participantData - participant document data from find participant query
  * @returns {Boolean} - true if participant has any clinical blood or urine collected derivations, false otherwise
- * // TODDO - Add flexibility for collection type, add option other than baseline and for follow up, etc.
+ * // TODO - Add flexibility for collection type, add option other than baseline and for follow up, etc.
 */
 const checkClinicalBloodOrUrineCollected = (participantData) => {
     const collectionDetailsBaseline = participantData?.[conceptIds.collectionDetails]?.[conceptIds.baseline.visitId];
@@ -688,9 +674,7 @@ const handleCheckInModal = async (data, visitConcept, query) => {
     const checkInOnContinue = async () => {
         try {
             const updatedResponse = await findParticipant(query);
-            console.log("🚀 ~ checkInOnContinue ~ updatedResponse:", updatedResponse)
             const updatedData = updatedResponse.data[0];
-            console.log("🚀 ~ checkInOnContinue ~ updatedData:", updatedData)
 
             dismissBiospecimenModal();
             specimenTemplate(updatedData);
@@ -894,9 +878,6 @@ const btnsClicked = async (connectId, formData) => {
  * @param {*} formData 
  */
 const clinicalBtnsClicked = async (participantData, formData) => { 
-console.log("🚀 ~ clinicalBtnsClicked ~ participantData:", participantData)
-console.log("🚀 ~ clinicalBtnsClicked ~ formData:", formData)
-
     removeAllErrors();
     const connectId = document.getElementById('clinicalSpecimenContinue').dataset.connectId;
     const participantName = document.getElementById('clinicalSpecimenContinue').dataset.participantName;
@@ -906,19 +887,14 @@ console.log("🚀 ~ clinicalBtnsClicked ~ formData:", formData)
     const accessionID3 = document.getElementById('accessionID3');
     const accessionID4 = document.getElementById('accessionID4');
     const selectedVisit = document.getElementById('visit-select').value;
+
     const isBloodCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.bloodCollectionSetting] === conceptIds.clinical;
-    console.log("🚀 ~ clinicalBtnsClicked ~ isClinicalBloodCollected:", isBloodCollected)
     const isUrineCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.urineCollectionSetting] === conceptIds.clinical;
-    console.log("🚀 ~ clinicalBtnsClicked ~ isClinicalUrineCollected:", isUrineCollected)
-    // const isResearchBloodCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.bloodCollectionSetting] === conceptIds.research;
-    // console.log("🚀 ~ clinicalBtnsClicked ~ isResearchBloodCollected:", isResearchBloodCollected)
-    // const isResearchUrineCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.urineCollectionSetting] === conceptIds.research;
-    // console.log("🚀 ~ clinicalBtnsClicked ~ isResearchUrineCollected:", isResearchUrineCollected)
     
     let hasError = false;
     let focus = true;
 
-    const modalContext = { // will be passed into modal functions
+    const modalContext = {
         participantData,
         accessionID2,
         accessionID4,
@@ -929,114 +905,121 @@ console.log("🚀 ~ clinicalBtnsClicked ~ formData:", formData)
         connectId,
     }
 
-    if (accessionID1 && 
-        !accessionID1.value && 
-        accessionID3 && 
-        !accessionID3.value) { // both input 1 and 3 are empty
-            hasError = true;
-            errorMessage('accessionID1', 'Please type Blood/Urine Accession ID from tube.', focus, true);
-            focus = false;
-    } else if (accessionID1 && 
-        accessionID1.value && 
-        !accessionID2.value && 
-        !accessionID2.classList.contains('disabled')) { // input 1 has value and input 2 no value and is NOT disabled
-            hasError = true;
-            errorMessage('accessionID2', 'Please re-type Blood Accession ID from tube.', focus, true);
-            focus = false;
-    } else if (accessionID2 &&
-        accessionID2.value &&
-        accessionID1 &&
-        !accessionID1.value) { // input 2 has value, input 1 has no value; NEWLY ADDED FOR INPUT 1 BLANK AND INPUT 2 HAS VALUE
-            hasError = true;
-            errorMessage('accessionID1', 'Blood Accession ID doesn\'t match', focus, true);
-            focus = false;
+    // Logic to display input error messages
+    if (
+        accessionID1 
+        && !accessionID1.value 
+        && accessionID3 
+        && !accessionID3.value
+    ) {
+        hasError = true;
+        errorMessage('accessionID1', 'Please type Blood/Urine Accession ID from tube.', focus, true);
+        focus = false;
+    } else if (
+        accessionID1 
+        && accessionID1.value 
+        && !accessionID2.value 
+        && !accessionID2.classList.contains('disabled')
+    ) {
+        hasError = true;
+        errorMessage('accessionID2', 'Please re-type Blood Accession ID from tube.', focus, true);
+        focus = false;
+    } else if (
+        accessionID2 
+        && accessionID2.value 
+        && accessionID1 
+        && !accessionID1.value
+    ) {
+        hasError = true;
+        errorMessage('accessionID1', 'Blood Accession ID doesn\'t match', focus, true);
+        focus = false;
 
-    } else if (accessionID1 && 
-        accessionID1.value && 
-        accessionID2.value && 
-        accessionID1.value !== accessionID2.value) { // input 1 and 2 have values, input 1 and 2 dont match; this only gives the red border to input 2 and not 1
-            hasError = true;
-            errorMessage('accessionID2', 'Blood Accession ID doesn\'t match', focus, true);
-            focus = false;
+    } else if (
+        accessionID1 
+        && accessionID1.value 
+        && accessionID2.value 
+        && accessionID1.value !== accessionID2.value
+    ) {
+        hasError = true;
+        errorMessage('accessionID2', 'Blood Accession ID doesn\'t match', focus, true);
+        focus = false;
     }
     
-    if (accessionID3 && 
-        accessionID3.value && 
-        !accessionID4.value && 
-        !accessionID4.classList.contains('disabled')) { // input 3, no input 4, input 4 has diasbled class
-            hasError = true;
-            errorMessage('accessionID4', 'Please re-type Urine Accession ID from tube.', focus, true);
-            focus = false;
-    } else if (accessionID3 && 
-        accessionID3.value && 
-        accessionID4.value && 
-        accessionID3.value !== accessionID4.value) { // input 3, no input 4, input 4 has diasbled class
-            hasError = true;
-            errorMessage('accessionID4', 'Urine Accession ID doesn\'t match', focus, true);
-            focus = false;
-    } else if (accessionID4 && 
-        accessionID4.value && 
-        accessionID3 && 
-        !accessionID3.value) {// add check for input 4, no input 3, NEWLY ADDED FOR INPUT 3 BLANK AND INPUT 4 HAS VALUE 
-            hasError = true;
-            errorMessage('accessionID3', 'Urine Accession ID doesn\'t match', focus, true);
-            focus = false;
-            console.log("no match. Input 4 has value, input 3 has no value")
-    } else if (!selectedVisit) { // Can this be separated? 
-            hasError = true;
-            errorMessage('visit-select', 'Visit Type is not selected', focus, true);
-            focus = false;
+    if (
+        accessionID3 
+        && accessionID3.value 
+        && !accessionID4.value 
+        && !accessionID4.classList.contains('disabled')
+    ) {
+        hasError = true;
+        errorMessage('accessionID4', 'Please re-type Urine Accession ID from tube.', focus, true);
+        focus = false;
+    } else if (
+        accessionID3 
+        && accessionID3.value 
+        && accessionID4.value 
+        && accessionID3.value !== accessionID4.value
+    ) {
+        hasError = true;
+        errorMessage('accessionID4', 'Urine Accession ID doesn\'t match', focus, true);
+        focus = false;
+    } else if (
+        accessionID4 
+        && accessionID4.value 
+        && accessionID3 
+        && !accessionID3.value
+    ) {
+        hasError = true;
+        errorMessage('accessionID3', 'Urine Accession ID doesn\'t match', focus, true);
+        focus = false;
+    } else if (!selectedVisit) {
+        hasError = true;
+        errorMessage('visit-select', 'Visit Type is not selected', focus, true);
+        focus = false;
     }
 
     if (hasError) return;
-    // error checking for any missing input fields
-    // const isBloodCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.bloodCollectionSetting] === conceptIds.clinical; 
-    // console.log("🚀 ~ clinicalBtnsClicked ~ isBloodCollected:", isBloodCollected)
-    // const isUrineCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.urineCollectionSetting] === conceptIds.clinical;
-    // console.log("🚀 ~ clinicalBtnsClicked ~ isUrineCollected:", isUrineCollected)
-    
 
-    // let confirmVal = 'No';
-    // clinicalSpecimensCollectedModal(participantData, conceptIds.bloodCollectionSetting, conceptIds.urineCollectionSetting);
-
-    if (!hasError && accessionID2.value && accessionID4.value) { // both inputs added
+    // Logic to trigger modals
+    if (!hasError 
+        && accessionID2.value 
+        && accessionID4.value
+    ) {
         const collectedModalData = await displayClinicalSpecimenCollectedModal(modalContext, isBloodCollected, isUrineCollected);
-        console.log("🚀 ~ clinicalBtnsClicked ~ modalData:", collectedModalData)
-        if (!collectedModalData) return; // if user clicked no on the modal
+        if (!collectedModalData) return;
 
-        triggerConfirmationModal(collectedModalData); // this will trigger the confirmation modal
-    } else if (accessionID1 && accessionID1.value && accessionID3 && !accessionID3.value) { // For only blood accession id inputs
-        // this can be refactored to a function
+        triggerConfirmationModal(collectedModalData);
+    } else if (
+        accessionID1 
+        && accessionID1.value 
+        && accessionID3 
+        && !accessionID3.value
+    ) {
         const confirmCollectedData = await displayClinicalSpecimenCollectedModal(modalContext, isBloodCollected, isUrineCollected);
-        console.log("🚀 ~ clinicalBtnsClicked ~ confirmCollectedData:", confirmCollectedData)
-        if (!confirmCollectedData) return; // if user clicked no on the modal
+        if (!confirmCollectedData) return;
+
         const missingModalData = await displayClinicalSpecimenMissingModal(confirmCollectedData);
-        console.log("🚀 ~ clinicalBtnsClicked ~ missingModalData:", typeof missingModalData)
-        if (!missingModalData) return; // if user clicked no on the modal
+        if (!missingModalData) return;
 
-        console.log("missingModalData!!!!!!", missingModalData)
-        // if (missingModalData?.confirmVal === 'No') return; // user clicked no on the modal
-        triggerConfirmationModal(missingModalData); // this will trigger the confirmation modal
-
-    } else if (accessionID1 && !accessionID1.value && accessionID3 && accessionID3.value) { // For only urine accession id inputs
+        triggerConfirmationModal(missingModalData);
+    } else if (
+        accessionID1 
+        && !accessionID1.value 
+        && accessionID3 
+        && accessionID3.value
+    ) {
         const confirmCollectedData = await displayClinicalSpecimenCollectedModal(modalContext, isBloodCollected, isUrineCollected);
-        console.log("🚀 ~ clinicalBtnsClicked ~ confirmCollectedData:", confirmCollectedData)
-        if (!confirmCollectedData) return; // if user clicked no on the modal
-        const missingModalData = await displayClinicalSpecimenMissingModal(confirmCollectedData);
-        console.log("🚀 ~ clinicalBtnsClicked ~ missingModalData:", typeof missingModalData)
-        if (!missingModalData) return; // if user clicked no on the modal
+        if (!confirmCollectedData) return;
 
-        console.log("missingModalData!!!!!!", missingModalData)
-        // if (missingModalData?.confirmVal === 'No') return; // user clicked no on the modal
+        const missingModalData = await displayClinicalSpecimenMissingModal(confirmCollectedData);
+        if (!missingModalData) return;
+
         triggerConfirmationModal(missingModalData);
     }
 };
 
 const triggerConfirmationModal = (modalData) => {
-    console.log("modal data", modalData.context)  
     const { accessionID2, accessionID4, participantName, selectedVisit, formData, connectId } = modalData.modalContext;
-    console.log("invoked",modalData.modalContext)
-    console.log("🚀 ~ confirmationModal ~ modalData:", modalData)
 
     const button = document.createElement('button');
     button.dataset.target = '#modalShowMoreData';
@@ -1044,9 +1027,11 @@ const triggerConfirmationModal = (modalData) => {
     document.getElementById('root').appendChild(button);
     button.click();
     document.getElementById('root').removeChild(button);
+
     const header = document.getElementById('modalHeader');
     const body = document.getElementById('modalBody');
     header.innerHTML = `Confirm Accession ID`
+
     let template =  `Blood Accession ID: ${accessionID2.value ? accessionID2.value : 'N/A' } <br />
     Urine Accession ID: ${accessionID4.value ? accessionID4.value : 'N/A' } <br />
     Confirm ID is correct for participant: ${participantName}`
@@ -1061,7 +1046,7 @@ const triggerConfirmationModal = (modalData) => {
 
     const noBtn = document.getElementById('cancel');
     noBtn.addEventListener("click", async e => {
-        return
+        return;
     })
 
     const yesBtn = document.getElementById('proceedNextPage');
@@ -1076,7 +1061,7 @@ const triggerConfirmationModal = (modalData) => {
             hideAnimation();
         }
     }) 
-}
+};
 
 
 const proceedToSpecimenPage = async (accessionID1, accessionID3, selectedVisit, formData, connectId) => {
@@ -2825,24 +2810,26 @@ const searchAvailableCollectionsForSpecimen = (specimenId) => {
 }
 
 /**
- * displays a modal to confirm if the user wants to continue with collected blood and/or urine specimens
+ * For Clinical dashboard, displays a modal to confirm if the user wants to continue with collected blood and/or urine specimens
  * @param {object} modalContext - context object containing information about the modal
  * @param {boolean} isBloodCollected - flag indicating if blood specimen from clinical is collected
  * @param {boolean} isUrineCollected - flag indicating if urine specimen from clinical is collected
- * @returns {Promise} - resolves with the modalContext if user clicks "Yes" or from no collected specimens, otherwise resolves with null
+ * @returns {Promise<object|null>} - resolves with the modalContext if user clicks "Yes" or from no collected specimens, otherwise resolves with null
 */
 
 const displayClinicalSpecimenCollectedModal = (modalContext, isBloodCollected, isUrineCollected) => {
-    console.log("isBloodCollected, isUrineCollected", isBloodCollected, isUrineCollected)
     if (!isBloodCollected && !isUrineCollected) return Promise.resolve({ modalContext });
+
     const button = document.createElement('button');
     button.dataset.target = '#biospecimenModal';
     button.dataset.toggle = 'modal';
     document.getElementById('root').appendChild(button);
     button.click();
     document.getElementById('root').removeChild(button);
+
     const header = document.getElementById('biospecimenModalHeader');
     const body = document.getElementById('biospecimenModalBody');
+
     const modalButtons = `
     <br />
     <div style="display:inline-block; margin-top:20px;">
@@ -2864,7 +2851,6 @@ const displayClinicalSpecimenCollectedModal = (modalContext, isBloodCollected, i
     
     return new Promise((resolve) => {
         const noBtn = document.getElementById('noTrigger');
-        console.log("🚀 ~ returnnewPromise ~ noBtn:", noBtn)
         noBtn.addEventListener("click", () => {
             resolve(null);
         });
@@ -2875,27 +2861,26 @@ const displayClinicalSpecimenCollectedModal = (modalContext, isBloodCollected, i
     })
 };
 
-// Takes in participantData
+/**
+ *  * For Research dashboard, displays a modal to confirm if the user wants to continue with any collected samples (blood, urine, mouthwash)
+ * @param {object} participantData - a data object document from the participants collection
+ * @returns {Promise<null|boolean>} - resolves with true if user clicks "Yes", otherwise resolves with null
+ */
 const displayResearchSpecimenCollectedModal = async (participantData) => {
 
-    console.log("participantData", participantData)
     const selectVisitConceptId = document.getElementById('visit-select').value;
-    console.log("🚀 ~ addEventCheckInCompleteForm ~ selectVisitConceptId:", selectVisitConceptId)
-    
     const isBloodCollected = participantData[conceptIds.collectionDetails]?.[selectVisitConceptId]?.[conceptIds.bloodCollectionSetting] === conceptIds.research; 
-    console.log("🚀 ~ clinicalBtnsClicked ~ conceptIds.bloodCollectionSetting:", conceptIds.bloodCollectionSetting)
-    console.log("🚀 ~ clinicalBtnsClicked ~ isBloodCollected:", isBloodCollected)
     const isUrineCollected = participantData[conceptIds.collectionDetails]?.[selectVisitConceptId]?.[conceptIds.urineCollectionSetting] === conceptIds.research;
-    console.log("🚀 ~ displayResearchSpecimenCollectedModal ~ isUrineCollected:", isUrineCollected)
-    console.log("🚀 ~ clinicalBtnsClicked ~ conceptIds.urineCollectionSetting:", conceptIds.urineCollectionSetting)
     const isMouthWashCollected = participantData[conceptIds.collectionDetails]?.[selectVisitConceptId]?.[conceptIds.mouthwashCollectionSetting] === conceptIds.research;
-    console.log("🚀 ~ displayResearchSpecimenCollectedModal ~ conceptIds.mouthwashCollectionSetting:", conceptIds.mouthwashCollectionSetting)
-    console.log("🚀 ~ displayResearchSpecimenCollectedModal ~ isMouthWashCollected:", isMouthWashCollected)
-    if (!isBloodCollected && !isUrineCollected && !isMouthWashCollected) { 
-        return;
+
+    if (
+        !isBloodCollected 
+        && !isUrineCollected 
+        && !isMouthWashCollected
+    ) { 
+        return new Promise ((resolve) => resolve(null));
     }
     
-    // Modal template
     const button = document.createElement('button');
     button.dataset.target = '#biospecimenCollected';
     button.dataset.toggle = 'modal';
@@ -2903,18 +2888,18 @@ const displayResearchSpecimenCollectedModal = async (participantData) => {
     button.click();
     document.getElementById('root').removeChild(button);
 
-    
-
     const header = document.getElementById('biospecimenModalHeaderCollected');
     const body = document.getElementById('biospecimenModalBodyCollected');
-    console.log("🚀 ~ displayResearchSpecimenCollectedModal ~ body:", body)
+
     let template;
 
-    if (isBloodCollected ||
-        isUrineCollected ||
-        isMouthWashCollected) {
-            header.innerHTML = 'Samples Already Collected';
-            template = 'This participant already has samples collected for this timepoint. Do you wish to continue with check-in?';
+    if (
+        isBloodCollected 
+        || isUrineCollected 
+        || isMouthWashCollected
+    ) {
+        header.innerHTML = 'Samples Already Collected';
+        template = 'This participant already has samples collected for this timepoint. Do you wish to continue with check-in?';
     } 
 
     template += `
@@ -2937,18 +2922,16 @@ const displayResearchSpecimenCollectedModal = async (participantData) => {
             resolve(true);
         });
     })
-}
+};
 
 
 /**
  * Displays a modal to confirm if the user wants to continue with missing blood and/or urine specimens
  * @param {object} modalData - data object containing information about the modal
- * @returns {Promise} - resolves with the modalData if user clicks "Yes", otherwise resolves with null
+ * @returns {Promise <object|null>} - resolves with the modalData if user clicks "Yes", otherwise resolves with null
 */
 const displayClinicalSpecimenMissingModal = (modalData) => { 
     const { accessionID2, accessionID4 } = modalData?.modalContext;
-    console.log("accessionID2", accessionID2, "--", "accessionID2.value", accessionID2?.value)
-    console.log("accessionID4", accessionID4, "--", "accessionID4.value", accessionID4?.value)
 
     const button = document.createElement('button');
     button.dataset.target = '#biospecimenModalExtra';
@@ -2956,7 +2939,6 @@ const displayClinicalSpecimenMissingModal = (modalData) => {
     document.getElementById('root').appendChild(button);
     button.click();
     document.getElementById('root').removeChild(button);
-
 
     const header = document.getElementById('biospecimenModalExtraHeader');
     const body = document.getElementById('biospecimenModalBodyExtraBody');
@@ -3030,9 +3012,11 @@ export const checkAccessionMatch = () => {
             removeSingleError('accessionID2')
         }
 
-        if (accessionId1.value.length > 0 && 
-            accessionId2.value.length > 0 && 
-            accessionId1.value !== accessionId2.value) {
+        if (
+            accessionId1.value.length > 0 
+            && accessionId2.value.length > 0 
+            && accessionId1.value !== accessionId2.value
+        ) {
             errorMessage('accessionID1', 'Blood Accession ID doesn\'t match', focus, true);
         }
     });
@@ -3042,9 +3026,10 @@ export const checkAccessionMatch = () => {
             removeSingleError('accessionID3')
             removeSingleError('accessionID4')
         }
-        if (accessionId3.value.length > 0 && 
-            accessionId4.value.length > 0 && 
-            accessionId3.value !== accessionId4.value) {
+        if (accessionId3.value.length > 0 
+            && accessionId4.value.length > 0 
+            && accessionId3.value !== accessionId4.value
+        ) {
             errorMessage('accessionID3', 'Urine Accession ID doesn\'t match', focus, true);
         }
     });

--- a/src/events.js
+++ b/src/events.js
@@ -553,9 +553,14 @@ export const addGoToSpecimenLinkEvent = () => {
 };
 
 export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
+    console.log("🚀 ~ addEventCheckInCompleteForm ~ isCheckedIn:", isCheckedIn)
     const form = document.getElementById('checkInCompleteForm');
     form && form.addEventListener('submit', async e => {
         e.preventDefault();
+
+        // const selectVisitConceptId = document.getElementById('visit-select').value;
+        // console.log("🚀 ~ addEventCheckInCompleteForm ~ selectVisitConceptId:", selectVisitConceptId)
+
         try {
             const btnCheckIn = document.getElementById('checkInComplete');
             
@@ -591,7 +596,7 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
                         }
                     }
                 }
-    
+
                 await handleCheckInModal(data, visitConcept, query);
                 btnCheckIn.disabled = true;
             }
@@ -650,7 +655,7 @@ const handleCheckInWarning = async (visit, data, collection) => {
 
     return userConfirmed;
 }
-
+// TODO HERE~
 const handleCheckInModal = async (data, visitConcept, query) => {
     await checkInParticipant(data, visitConcept);
 
@@ -666,7 +671,9 @@ const handleCheckInModal = async (data, visitConcept, query) => {
     const checkInOnContinue = async () => {
         try {
             const updatedResponse = await findParticipant(query);
+            console.log("🚀 ~ checkInOnContinue ~ updatedResponse:", updatedResponse)
             const updatedData = updatedResponse.data[0];
+            console.log("🚀 ~ checkInOnContinue ~ updatedData:", updatedData)
 
             dismissBiospecimenModal();
             specimenTemplate(updatedData);
@@ -723,11 +730,11 @@ export const addEventSpecimenLinkForm = (formData) => {
     });
 };
 
-export const addEventClinicalSpecimenLinkForm = (formData) => {
+export const addEventClinicalSpecimenLinkForm = (participantData, formData) => {
     const form = document.getElementById('clinicalSpecimenContinue');
     form.addEventListener('click', async (e) => {
         e.preventDefault();
-        clinicalBtnsClicked(formData);
+        clinicalBtnsClicked(participantData, formData);
     });
 };
 
@@ -865,12 +872,16 @@ const btnsClicked = async (connectId, formData) => {
     }
 }
 
-
+// Code can be refactored for input handling
+// add the collection setting as parameter, Add data object with participant Data
 /**
  * Check accession number inputs after clicking 'Submit' button
  * @param {*} formData 
  */
-const clinicalBtnsClicked = async (formData) => { 
+const clinicalBtnsClicked = async (participantData, formData) => { 
+console.log("🚀 ~ clinicalBtnsClicked ~ participantData:", participantData)
+console.log("🚀 ~ clinicalBtnsClicked ~ formData:", formData)
+// console.log("formData[173836415][266600170][592099155]", formData[173836415][266600170][592099155])
 
     removeAllErrors();
     const connectId = document.getElementById('clinicalSpecimenContinue').dataset.connectId;
@@ -885,42 +896,93 @@ const clinicalBtnsClicked = async (formData) => {
     let hasError = false;
     let focus = true;
 
-    if (accessionID1 && !accessionID1.value && accessionID3 && !accessionID3.value) {
-        hasError = true;
-        errorMessage('accessionID1', 'Please type Blood/Urine Accession ID from tube.', focus, true);
-        focus = false;
+    // accessionID2, accessionID4, participantName, hasError, confirmVal, selectedVisit, formData, connectId
+    // TODO LATER: !!!
+    const modalContext = { // will be passed into modal functions
+        participantData,
+        accessionID2,
+        accessionID4,
+        participantName,
+        hasError,
+        selectedVisit,
+        formData,
+        connectId,
     }
-    else if (accessionID1 && accessionID1.value && !accessionID2.value && !accessionID2.classList.contains('disabled')) {
-        hasError = true;
-        errorMessage('accessionID2', 'Please re-type Blood Accession ID from tube.', focus, true);
-        focus = false;
-    }
-    else if (accessionID1 && accessionID1.value && accessionID2.value && accessionID1.value !== accessionID2.value) {
-        hasError = true;
-        errorMessage('accessionID2', 'Blood Accession ID doesn\'t match', focus, true);
-        focus = false;
+
+    if (accessionID1 && 
+        !accessionID1.value && 
+        accessionID3 && 
+        !accessionID3.value) { // both input 1 and 3 are empty
+            hasError = true;
+            errorMessage('accessionID1', 'Please type Blood/Urine Accession ID from tube.', focus, true);
+            focus = false;
+    } else if (accessionID1 && 
+        accessionID1.value && 
+        !accessionID2.value && 
+        !accessionID2.classList.contains('disabled')) { // input 1 has value and input 2 no value and is NOT disabled
+            hasError = true;
+            errorMessage('accessionID2', 'Please re-type Blood Accession ID from tube.', focus, true);
+            focus = false;
+    } else if (accessionID2 &&
+        accessionID2.value &&
+        accessionID1 &&
+        !accessionID1.value) { // input 2 has value, input 1 has no value; NEWLY ADDED FOR INPUT 1 BLANK AND INPUT 2 HAS VALUE
+            hasError = true;
+            errorMessage('accessionID1', 'Blood Accession ID doesn\'t match', focus, true);
+            focus = false;
+
+    } else if (accessionID1 && 
+        accessionID1.value && 
+        accessionID2.value && 
+        accessionID1.value !== accessionID2.value) { // input 1 and 2 have values, input 1 and 2 dont match; this only gives the red border to input 2 and not 1
+            hasError = true;
+            errorMessage('accessionID2', 'Blood Accession ID doesn\'t match', focus, true);
+            focus = false;
     }
     
-    if (accessionID3 && accessionID3.value && !accessionID4.value && !accessionID4.classList.contains('disabled')) {
-        hasError = true;
-        errorMessage('accessionID4', 'Please re-type Urine Accession ID from tube.', focus, true);
-        focus = false;
-    }
-    else if (accessionID3 && accessionID3.value && accessionID4.value && accessionID3.value !== accessionID4.value) {
-        hasError = true;
-        errorMessage('accessionID4', 'Urine Accession ID doesn\'t match', focus, true);
-        focus = false;
-    }
-    else if (!selectedVisit) {
-        hasError = true;
-        errorMessage('visit-select', 'Visit Type is not selected', focus, true);
-        focus = false;
+    if (accessionID3 && 
+        accessionID3.value && 
+        !accessionID4.value && 
+        !accessionID4.classList.contains('disabled')) { // input 3, no input 4, input 4 has diasbled class
+            hasError = true;
+            errorMessage('accessionID4', 'Please re-type Urine Accession ID from tube.', focus, true);
+            focus = false;
+    } else if (accessionID3 && 
+        accessionID3.value && 
+        accessionID4.value && 
+        accessionID3.value !== accessionID4.value) { // input 3, no input 4, input 4 has diasbled class
+            hasError = true;
+            errorMessage('accessionID4', 'Urine Accession ID doesn\'t match', focus, true);
+            focus = false;
+    } else if (accessionID4 && 
+        accessionID4.value && 
+        accessionID3 && 
+        !accessionID3.value) {// add check for input 4, no input 3, NEWLY ADDED FOR INPUT 3 BLANK AND INPUT 4 HAS VALUE 
+            hasError = true;
+            errorMessage('accessionID3', 'Urine Accession ID doesn\'t match', focus, true);
+            focus = false;
+            console.log("no match. Input 4 has value, input 3 has no value")
+    } else if (!selectedVisit) { // Can this be separated? 
+            hasError = true;
+            errorMessage('visit-select', 'Visit Type is not selected', focus, true);
+            focus = false;
     }
 
     if (hasError) return;
-    let confirmVal = 'No';
+    // error checking for any missing input fields
 
-    if (accessionID1 && accessionID1.value && accessionID3 && !accessionID3.value) {
+
+    let confirmVal = 'No';
+    // clinicalSpecimensCollectedModal(participantData, conceptIds.bloodCollectionSetting, conceptIds.urineCollectionSetting);
+
+    if (!hasError && accessionID2.value && accessionID4.value) { // both inputs added
+        const modalData = await clinicalSpecimensCollectedModal(modalContext, conceptIds.bloodCollectionSetting, conceptIds.urineCollectionSetting);
+        triggerConfirmationModal(modalData); // this will trigger the confirmation modal
+    } else if (accessionID1 && accessionID1.value && accessionID3 && !accessionID3.value) { // For only blood accession id inputs
+        // this can be refactored to a function
+        console.log("test this output! else if")
+
+
         const button = document.createElement('button');
         button.dataset.target = '#biospecimenModal';
         button.dataset.toggle = 'modal';
@@ -953,10 +1015,7 @@ const clinicalBtnsClicked = async (formData) => {
             triggerConfirmationModal(accessionID2, accessionID4, participantName, hasError, confirmVal, selectedVisit, formData, connectId)
         })
 
-    }
-    
-    
-    if (accessionID1 && !accessionID1.value && accessionID3 && accessionID3.value) {
+    } else if (accessionID1 && !accessionID1.value && accessionID3 && accessionID3.value) { // For only urine accession id inputs
         const button = document.createElement('button');
         button.dataset.target = '#biospecimenModal';
         button.dataset.toggle = 'modal';
@@ -985,21 +1044,27 @@ const clinicalBtnsClicked = async (formData) => {
         const yesBtn = document.getElementById('yesTrigger')
         yesBtn.addEventListener("click", async e => {
             confirmVal = 'Yes'
-            triggerConfirmationModal(accessionID2, accessionID4, participantName, hasError, confirmVal, selectedVisit, formData, connectId)
+            triggerConfirmationModal(accessionID2, accessionID4, participantName, hasError, confirmVal, selectedVisit, formData, connectId) // confirmation modal 
         })
     }
 
-    if (!hasError && accessionID2.value && accessionID4.value) {
-        confirmationModal(accessionID1, accessionID3, participantName, selectedVisit, formData, connectId)
+}; // End of ClinicalBtnsClicked ********
+
+// Can add confirmation modal inside
+// proceedToSpecimenPage or redirectSpecimenPage
+const triggerConfirmationModal =  (modalData) => {
+    const { confirmVal } = modalData; 
+    const hasError = modalData?.modalContext?.hasError;
+    if (!hasError && confirmVal === 'Yes') {
+        confirmationModal(modalData)
     }
 }
 
-const triggerConfirmationModal =  (accessionID2, accessionID4, participantName, hasError, confirmVal, selectedVisit, formData, connectId) => {
-    if (!hasError && confirmVal === 'Yes') {
-        confirmationModal(accessionID2, accessionID4, participantName, selectedVisit, formData, connectId)
-}}
-
-const confirmationModal = (accessionID2, accessionID4, participantName, selectedVisit, formData, connectId) => {
+const confirmationModal = (modalData) => {
+    const { accessionID2, accessionID4, participantName, selectedVisit, formData, connectId } = modalData.modalContext;
+    console.log("accessionID2, accessionID4, participantName, selectedVisit, formData, connectId")
+    console.log(modalData.modalContext)
+    // return
     const button = document.createElement('button');
     button.dataset.target = '#modalShowMoreData';
     button.dataset.toggle = 'modal';
@@ -1020,6 +1085,7 @@ const confirmationModal = (accessionID2, accessionID4, participantName, selected
         </div>
     </div>`
     body.innerHTML = template;
+
     const noBtn = document.getElementById('cancel');
     noBtn.addEventListener("click", async e => {
         return
@@ -1030,6 +1096,44 @@ const confirmationModal = (accessionID2, accessionID4, participantName, selected
         (accessionID2.value) ? await proceedToSpecimenPage(accessionID2, accessionID4, selectedVisit, formData, connectId) :
         await redirectSpecimenPage(accessionID2, accessionID4, selectedVisit, formData, connectId)
     }) 
+}
+
+/**
+ * Displays a modal to notify user that both blood and urine was collected, or either a blood or a urine was collected.
+ * @param {Object} participantData - Participant data object.
+ * @param {Number} bloodCollectionSetting - Blood collection setting concept id.
+ * @param {Number} urineCollectionSetting - Urine collection setting concept id.
+*/
+const clinicalSpecimensCollectedModal = (modalContext, bloodCollectionSetting, urineCollectionSetting) => {
+    console.log("🚀 ~ clinicalSpecimensCollectedModal ~ urineCollectionSetting:", urineCollectionSetting)
+    console.log("🚀 ~ clinicalSpecimensCollectedModal ~ bloodCollectionSetting:", bloodCollectionSetting)
+
+    const { participantData } = modalContext;
+
+    // need selected visit for obtaining correct data from participantData
+    const selectedVisit = document.getElementById('visit-select').value;
+    // make into a single function that handles both, or blood, or urine
+
+    // Either of these two should be clinical concept Id (664882224)
+    const isBloodCollected = participantData[conceptIds.collectionDetails][selectedVisit][bloodCollectionSetting] === conceptIds.clinical; 
+    const isUrineCollected = participantData[conceptIds.collectionDetails][selectedVisit][urineCollectionSetting] === conceptIds.clinical;
+
+    // console.log("isBloodCollected", isBloodCollected)
+    // console.log("isUrineCollected", isUrineCollected)
+    /*
+    Add modal here?
+    Use case switch statement to determine the message to be displayed
+    
+    
+    
+    */
+
+
+    // Add case switch statement here
+
+    return clinicalCollectedModalContent(modalContext,isBloodCollected, isUrineCollected)
+
+    
 }
 
 const proceedToSpecimenPage = async (accessionID1, accessionID3, selectedVisit, formData, connectId) => {
@@ -2775,4 +2879,70 @@ const searchAvailableCollectionsForSpecimen = (specimenId) => {
         }
     }
     return false;
+}
+
+
+/* 
+Clinical modal template
+
+
+
+triggerConfirmationModal --> confirmation modal
+*/
+const clinicalCollectedModalContent = (modalContext, isBloodCollected, isUrineCollected) => {
+    const button = document.createElement('button');
+    let confirmVal = 'No';
+    const modalButtons = `
+    <br />
+    <div style="display:inline-block; margin-top:20px;">
+        <button type="button" class="btn btn-primary" data-dismiss="modal" target="_blank" id="yesTrigger">Yes</button>
+        <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank" id="noTrigger">NO</button>
+        </div>
+    </div>`
+    button.dataset.target = '#biospecimenModal';
+    button.dataset.toggle = 'modal';
+    document.getElementById('root').appendChild(button);
+    button.click();
+    document.getElementById('root').removeChild(button);
+    const header = document.getElementById('biospecimenModalHeader');
+    const body = document.getElementById('biospecimenModalBody');
+
+    if (isBloodCollected && isUrineCollected) {
+        header.innerHTML = `Blood and Urine Specimens Already Collected`
+        body.innerHTML = "This participant already has a blood and urine specimens collected for this timepoint. Do you wish to continue?" + modalButtons
+    } else if (isBloodCollected) { 
+        header.innerHTML = `Blood Specimen Already Collected`
+        body.innerHTML = "This participant already has a blood specimen collected for this timepoint. Do you wish to continue?" + modalButtons
+    } else if (isUrineCollected) { 
+        header.innerHTML = `Urine Specimen Already Collected`
+        body.innerHTML = "This participant already has a urine specimen collected for this timepoint. Do you wish to continue?" + modalButtons
+    } else {
+        return;
+    }
+
+    return new Promise( (resolve) => {
+        const noBtn = document.getElementById('noTrigger');
+        noBtn.addEventListener("click", async e => {
+            confirmVal = 'No';
+            resolve({ confirmVal });
+        });
+        const yesBtn = document.getElementById('yesTrigger');
+        yesBtn.addEventListener("click", async e => {
+            confirmVal = 'Yes';
+            resolve({ modalContext,confirmVal });
+        });
+    })
+
+    // const noBtn = document.getElementById('noTrigger')
+    // noBtn.addEventListener("click", async e => {
+    //     confirmVal = 'No'
+    // });
+
+    // const yesBtn = document.getElementById('yesTrigger')
+    // yesBtn.addEventListener("click", async e => {
+    //     confirmVal = 'Yes'
+    //     // triggerConfirmationModal(accessionID2, accessionID4, participantName, hasError, confirmVal, selectedVisit, formData, connectId) // confirmation modal 
+    // });
+
+
 }

--- a/src/events.js
+++ b/src/events.js
@@ -558,8 +558,6 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
     form && form.addEventListener('submit', async e => {
         e.preventDefault();
 
-        // const selectVisitConceptId = document.getElementById('visit-select').value;
-        // console.log("🚀 ~ addEventCheckInCompleteForm ~ selectVisitConceptId:", selectVisitConceptId)
 
         try {
             const btnCheckIn = document.getElementById('checkInComplete');
@@ -592,12 +590,30 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
                             let collection = response.data.filter(res => res[conceptIds.collection.selectedVisit] == visit.concept);
                             if (collection.length === 0) continue;
                             const confirmContinueCheckIn = await handleCheckInWarning(visit, data, collection);
+                            console.log("🚀 ~ addEventCheckInCompleteForm ~ confirmContinueCheckIn:", confirmContinueCheckIn)
                             if (!confirmContinueCheckIn) return;
                         }
                     }
                 }
 
-                await handleCheckInModal(data, visitConcept, query);
+                // Need to add condition to not run this if the user has no collection for a specific visit
+                console.log("!data?.[conceptIds.collectionDetails]?.visitConcept", !data?.[conceptIds.collectionDetails], "visit concept ---", visitConcept, "combined", data?.[conceptIds.collectionDetails]?.[visitConcept], "data?.[conceptIds.collectionDetails]",data?.[conceptIds.collectionDetails])
+                // if (!data?.[conceptIds.collectionDetails]?.visitConcept) {
+                // }
+                // return;
+                console.log("data", data);
+                console.log("[conceptIds.collectionDetails]", [conceptIds.collectionDetails])
+                console.log("visitConcept", visitConcept)
+                // console.log("data?.[conceptIds.collectionDetails]", data?.[conceptIds.collectionDetails])
+                console.log("data?.[conceptIds.collectionDetails]?.visitConcept", data?.[conceptIds.collectionDetails]?.[visitConcept])
+                if (data?.[conceptIds.collectionDetails]?.[visitConcept]) { // This function will run if there is a collection for a selected visit
+                    const confirmCollectedModal = await displayResearchSpecimenCollectedModal(data);
+                    console.log("🚀 ~ addEventCheckInCompleteForm ~ confirmCollectedModal:", confirmCollectedModal)
+                    if (!confirmCollectedModal) return;
+                }
+                // return;
+
+                await handleCheckInModal(data, visitConcept, query); 
                 btnCheckIn.disabled = true;
             }
         } catch (error) {
@@ -611,6 +627,7 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
  * Checks if the participant has any specimen collected (clinical blood or clinical urine) under baseline from the dashboard or collected clinical blood or urine derivations from the site EMR API. If participant has either a clinical blood or urine dashboard variable or other blood/urine derived variables from the site EMR API, show a notification and return true.
  * @param {Object} participantData - participant document data from find participant query
  * @returns {Boolean} - true if participant has any clinical blood or urine collected derivations, false otherwise
+ * // TODDO - Add flexibility for collection type, add option other than baseline and for follow up, etc.
 */
 const checkClinicalBloodOrUrineCollected = (participantData) => {
     const collectionDetailsBaseline = participantData?.[conceptIds.collectionDetails]?.[conceptIds.baseline.visitId];
@@ -655,7 +672,7 @@ const handleCheckInWarning = async (visit, data, collection) => {
 
     return userConfirmed;
 }
-// TODO HERE~
+
 const handleCheckInModal = async (data, visitConcept, query) => {
     await checkInParticipant(data, visitConcept);
 
@@ -681,7 +698,6 @@ const handleCheckInModal = async (data, visitConcept, query) => {
             showNotifications({ title: 'Error', body: 'There was an error checking in the participant. Please try again.' });
         }
     };
-
     showNotificationsCancelOrContinue(checkInMessage, 10000, checkInOnCancel, checkInOnContinue);
 }
 
@@ -889,7 +905,15 @@ console.log("🚀 ~ clinicalBtnsClicked ~ formData:", formData)
     const accessionID2 = document.getElementById('accessionID2');
     const accessionID3 = document.getElementById('accessionID3');
     const accessionID4 = document.getElementById('accessionID4');
-    const selectedVisit = document.getElementById('visit-select').value;   
+    const selectedVisit = document.getElementById('visit-select').value;
+    const isBloodCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.bloodCollectionSetting] === conceptIds.clinical;
+    console.log("🚀 ~ clinicalBtnsClicked ~ isClinicalBloodCollected:", isBloodCollected)
+    const isUrineCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.urineCollectionSetting] === conceptIds.clinical;
+    console.log("🚀 ~ clinicalBtnsClicked ~ isClinicalUrineCollected:", isUrineCollected)
+    // const isResearchBloodCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.bloodCollectionSetting] === conceptIds.research;
+    // console.log("🚀 ~ clinicalBtnsClicked ~ isResearchBloodCollected:", isResearchBloodCollected)
+    // const isResearchUrineCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.urineCollectionSetting] === conceptIds.research;
+    // console.log("🚀 ~ clinicalBtnsClicked ~ isResearchUrineCollected:", isResearchUrineCollected)
     
     let hasError = false;
     let focus = true;
@@ -966,20 +990,20 @@ console.log("🚀 ~ clinicalBtnsClicked ~ formData:", formData)
 
     if (hasError) return;
     // error checking for any missing input fields
-    const isBloodCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.bloodCollectionSetting] === conceptIds.clinical; 
-    console.log("🚀 ~ clinicalBtnsClicked ~ conceptIds.bloodCollectionSetting:", conceptIds.bloodCollectionSetting)
-    console.log("🚀 ~ clinicalBtnsClicked ~ isBloodCollected:", isBloodCollected)
-    const isUrineCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.urineCollectionSetting] === conceptIds.clinical;
-    console.log("🚀 ~ clinicalBtnsClicked ~ conceptIds.urineCollectionSetting:", conceptIds.urineCollectionSetting)
-    console.log("🚀 ~ clinicalBtnsClicked ~ isUrineCollected:", isUrineCollected)
+    // const isBloodCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.bloodCollectionSetting] === conceptIds.clinical; 
+    // console.log("🚀 ~ clinicalBtnsClicked ~ isBloodCollected:", isBloodCollected)
+    // const isUrineCollected = participantData[conceptIds.collectionDetails]?.[selectedVisit]?.[conceptIds.urineCollectionSetting] === conceptIds.clinical;
+    // console.log("🚀 ~ clinicalBtnsClicked ~ isUrineCollected:", isUrineCollected)
+    
 
     // let confirmVal = 'No';
     // clinicalSpecimensCollectedModal(participantData, conceptIds.bloodCollectionSetting, conceptIds.urineCollectionSetting);
 
     if (!hasError && accessionID2.value && accessionID4.value) { // both inputs added
         const collectedModalData = await displayClinicalSpecimenCollectedModal(modalContext, isBloodCollected, isUrineCollected);
-        if (!collectedModalData) return; // if user clicked no on the modal
         console.log("🚀 ~ clinicalBtnsClicked ~ modalData:", collectedModalData)
+        if (!collectedModalData) return; // if user clicked no on the modal
+
         triggerConfirmationModal(collectedModalData); // this will trigger the confirmation modal
     } else if (accessionID1 && accessionID1.value && accessionID3 && !accessionID3.value) { // For only blood accession id inputs
         // this can be refactored to a function
@@ -1004,9 +1028,8 @@ console.log("🚀 ~ clinicalBtnsClicked ~ formData:", formData)
 
         console.log("missingModalData!!!!!!", missingModalData)
         // if (missingModalData?.confirmVal === 'No') return; // user clicked no on the modal
-        triggerConfirmationModal(missingModalData); // 
+        triggerConfirmationModal(missingModalData);
     }
-
 };
 
 const triggerConfirmationModal = (modalData) => {
@@ -1045,11 +1068,11 @@ const triggerConfirmationModal = (modalData) => {
     yesBtn.addEventListener("click", async e => {
         if (accessionID2.value) {
             showAnimation();
-            await proceedToSpecimenPage(accessionID2, accessionID4, selectedVisit, formData, connectId)
+            await proceedToSpecimenPage(accessionID2, accessionID4, selectedVisit, formData, connectId);
             hideAnimation();
         } else {
             showAnimation();
-            await redirectSpecimenPage(accessionID2, accessionID4, selectedVisit, formData, connectId)
+            await redirectSpecimenPage(accessionID2, accessionID4, selectedVisit, formData, connectId);
             hideAnimation();
         }
     }) 
@@ -2804,13 +2827,14 @@ const searchAvailableCollectionsForSpecimen = (specimenId) => {
 /**
  * displays a modal to confirm if the user wants to continue with collected blood and/or urine specimens
  * @param {object} modalContext - context object containing information about the modal
- * @param {boolean} isBloodCollected - flag indicating if blood specimen is collected
- * @param {boolean} isUrineCollected - flag indicating if urine specimen is collected
- * @returns {Promise} - resolves with the modalContext if user clicks "Yes", otherwise resolves with null
+ * @param {boolean} isBloodCollected - flag indicating if blood specimen from clinical is collected
+ * @param {boolean} isUrineCollected - flag indicating if urine specimen from clinical is collected
+ * @returns {Promise} - resolves with the modalContext if user clicks "Yes" or from no collected specimens, otherwise resolves with null
 */
 
 const displayClinicalSpecimenCollectedModal = (modalContext, isBloodCollected, isUrineCollected) => {
     console.log("isBloodCollected, isUrineCollected", isBloodCollected, isUrineCollected)
+    if (!isBloodCollected && !isUrineCollected) return Promise.resolve({ modalContext });
     const button = document.createElement('button');
     button.dataset.target = '#biospecimenModal';
     button.dataset.toggle = 'modal';
@@ -2840,6 +2864,7 @@ const displayClinicalSpecimenCollectedModal = (modalContext, isBloodCollected, i
     
     return new Promise((resolve) => {
         const noBtn = document.getElementById('noTrigger');
+        console.log("🚀 ~ returnnewPromise ~ noBtn:", noBtn)
         noBtn.addEventListener("click", () => {
             resolve(null);
         });
@@ -2850,23 +2875,80 @@ const displayClinicalSpecimenCollectedModal = (modalContext, isBloodCollected, i
     })
 };
 
+// Takes in participantData
+const displayResearchSpecimenCollectedModal = async (participantData) => {
+
+    console.log("participantData", participantData)
+    const selectVisitConceptId = document.getElementById('visit-select').value;
+    console.log("🚀 ~ addEventCheckInCompleteForm ~ selectVisitConceptId:", selectVisitConceptId)
+    
+    const isBloodCollected = participantData[conceptIds.collectionDetails]?.[selectVisitConceptId]?.[conceptIds.bloodCollectionSetting] === conceptIds.research; 
+    console.log("🚀 ~ clinicalBtnsClicked ~ conceptIds.bloodCollectionSetting:", conceptIds.bloodCollectionSetting)
+    console.log("🚀 ~ clinicalBtnsClicked ~ isBloodCollected:", isBloodCollected)
+    const isUrineCollected = participantData[conceptIds.collectionDetails]?.[selectVisitConceptId]?.[conceptIds.urineCollectionSetting] === conceptIds.research;
+    console.log("🚀 ~ displayResearchSpecimenCollectedModal ~ isUrineCollected:", isUrineCollected)
+    console.log("🚀 ~ clinicalBtnsClicked ~ conceptIds.urineCollectionSetting:", conceptIds.urineCollectionSetting)
+    const isMouthWashCollected = participantData[conceptIds.collectionDetails]?.[selectVisitConceptId]?.[conceptIds.mouthwashCollectionSetting] === conceptIds.research;
+    console.log("🚀 ~ displayResearchSpecimenCollectedModal ~ conceptIds.mouthwashCollectionSetting:", conceptIds.mouthwashCollectionSetting)
+    console.log("🚀 ~ displayResearchSpecimenCollectedModal ~ isMouthWashCollected:", isMouthWashCollected)
+    if (!isBloodCollected && !isUrineCollected && !isMouthWashCollected) { 
+        return;
+    }
+    
+    // Modal template
+    const button = document.createElement('button');
+    button.dataset.target = '#biospecimenCollected';
+    button.dataset.toggle = 'modal';
+    document.getElementById('root').appendChild(button);
+    button.click();
+    document.getElementById('root').removeChild(button);
+
+    
+
+    const header = document.getElementById('biospecimenModalHeaderCollected');
+    const body = document.getElementById('biospecimenModalBodyCollected');
+    console.log("🚀 ~ displayResearchSpecimenCollectedModal ~ body:", body)
+    let template;
+
+    if (isBloodCollected ||
+        isUrineCollected ||
+        isMouthWashCollected) {
+            header.innerHTML = 'Samples Already Collected';
+            template = 'This participant already has samples collected for this timepoint. Do you wish to continue with check-in?';
+    } 
+
+    template += `
+        <br />
+        <div style="display:inline-block; margin-top:20px;">
+            <button type="button" class="btn btn-primary" data-dismiss="modal" target="_blank" data-toggle="modal" id="yesTrigger_Modal2">Yes</button>
+            <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank" id="noTrigger_Modal2">NO</button>
+            </div>
+        </div>`;
+    body.innerHTML = template;
+
+    return new Promise ((resolve) => {
+        const noBtn = document.getElementById('noTrigger_Modal2');
+        noBtn.addEventListener("click", () => {
+            resolve(null);
+        });
+
+        const yesBtn = document.getElementById('yesTrigger_Modal2');
+        yesBtn.addEventListener("click", () => {
+            resolve(true);
+        });
+    })
+}
+
 
 /**
  * Displays a modal to confirm if the user wants to continue with missing blood and/or urine specimens
  * @param {object} modalData - data object containing information about the modal
- * returns {Promise} - resolves with the modalData if user clicks "Yes", otherwise resolves with null
+ * @returns {Promise} - resolves with the modalData if user clicks "Yes", otherwise resolves with null
 */
 const displayClinicalSpecimenMissingModal = (modalData) => { 
-    
-    const { accessionID2, accessionID4, participantName, hasError, selectedVisit, formData, connectId } = modalData?.modalContext;
-    // let confirmVal = modalData?.modalContext?.confirmVal;
-    // if (modalData?.modalContext?.confirmVal === 'No') return;
-    // if (confirmVal === 'No') return;
+    const { accessionID2, accessionID4 } = modalData?.modalContext;
     console.log("accessionID2", accessionID2, "--", "accessionID2.value", accessionID2?.value)
     console.log("accessionID4", accessionID4, "--", "accessionID4.value", accessionID4?.value)
-
-    // determine if accedsionID2 or accessionID4 is missing
-    // based on what is missing, display appropriate modal content
 
     const button = document.createElement('button');
     button.dataset.target = '#biospecimenModalExtra';
@@ -2901,12 +2983,12 @@ const displayClinicalSpecimenMissingModal = (modalData) => {
     
     return new Promise ((resolve) => {
         const noBtn = document.getElementById('noTrigger_Modal2');
-        noBtn.addEventListener("click", async e => {
+        noBtn.addEventListener("click", () => {
             resolve(null);
         });
 
         const yesBtn = document.getElementById('yesTrigger_Modal2');
-        yesBtn.addEventListener("click", async e => {
+        yesBtn.addEventListener("click", () => {
             resolve(modalData);
         });
     })

--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -76,7 +76,7 @@ export const checkInTemplate = async (data, checkOutFlag) => {
             <hr/>
     `;
     
-    template += await participantStatus(data, collections, isCheckedIn);
+    template += participantStatus(data, collections, isCheckedIn);
 
 
     if (canCheckIn) {
@@ -114,7 +114,7 @@ const reloadCheckOutReports = (id) => {
     });
 }
 
-const participantStatus = (data, collections, isCheckedIn) => {    
+const participantStatus = (data, collections, isCheckedIn) => {
     let bloodCollection;
     let urineCollection;
     let mouthwashCollection;

--- a/src/pages/specimen.js
+++ b/src/pages/specimen.js
@@ -37,7 +37,7 @@ export const specimenTemplate = async (data, formData) => {
 
     template += `<div id="specimenLinkForm" data-participant-token="${data.token}" data-connect-id="${data.Connect_ID}">`;
         
-    if(workflow === 'research') {
+    if (workflow === 'research') {
         let visit = visitType.filter(visit => visit.concept === getCheckedInVisit(data))[0];
             
         template += `
@@ -50,7 +50,7 @@ export const specimenTemplate = async (data, formData) => {
                 
         const siteAcronym = getSiteAcronym();
                 
-        if(siteLocations[workflow] && siteLocations[workflow][siteAcronym]) {
+        if (siteLocations[workflow] && siteLocations[workflow][siteAcronym]) {
 
             
             // For the purposes of 1008 we are filtering out some locations.
@@ -103,8 +103,7 @@ export const specimenTemplate = async (data, formData) => {
                 </div>
             </div>`;
 
-    } 
-    else if(isSpecimenLinkForm2) {// clinical specimen page 2
+    } else if(isSpecimenLinkForm2) {// clinical specimen page 2
         let visit = visitType.filter(visit => visit.concept === formData['331584571'].toString())[0];
             template += `<div class="row">
                             <div class="column">
@@ -130,8 +129,7 @@ export const specimenTemplate = async (data, formData) => {
                                 <button class="btn btn-outline-primary float-right" data-connect-id="${data.Connect_ID}" type="submit" id="clinicalSpecimenContinueTwo">Submit</button>
                             </div>
                         </div>`
-    } 
-    else {// clinical specimen page 1
+    } else {// clinical specimen page 1
         template += `<div class="form-group row">`
         const siteAcronym = getSiteAcronym();
         template += `<select class="custom-select" id="visit-select">
@@ -153,6 +151,7 @@ export const specimenTemplate = async (data, formData) => {
             </div>
             <div class="form-group row">
                 <input autocomplete="off" type="text" class="form-control col-md-5 offset-4" placeholder="Re-Enter (scan/type) in Accession ID from Blood Tube" id="accessionID2" maxlength="11"/>
+                <div id="accessionId2Error" class="invalid-feedback col-md-5 offset-4 form-helper-text" style="padding-left:0; "></div>
             </div>
             </br>
             <div class="form-group row">
@@ -163,6 +162,7 @@ export const specimenTemplate = async (data, formData) => {
             </div>
             <div class="form-group row">
                 <input autocomplete="off" type="text" class="form-control col-md-5 offset-4" placeholder="Re-Enter (scan/type) in Accession ID from Urine Tube" id="accessionID4" maxlength="11"/>
+                <div id="accessionId4Error" class="invalid-feedback col-md-5 offset-4 form-helper-text" style="padding-left:0; "></div>
             </div>
             
         <div class="form-group row">
@@ -178,32 +178,36 @@ export const specimenTemplate = async (data, formData) => {
 
     document.getElementById('contentBody').innerHTML = template;
      
-    if(workflow === 'research') {
+    if (workflow === 'research') {
         document.getElementById('scanSpecimenID2').onpaste = e => e.preventDefault();
         
         addSelectionEventListener("collectionLocation", "specimenLink_location");
         collectionInputValidator(['scanSpecimenID', 'scanSpecimenID2']);
 
         addEventSpecimenLinkForm(formData);
-    } 
-    else if (isSpecimenLinkForm2) {// clinical specimen page 2
+    } else if (isSpecimenLinkForm2) {// clinical specimen page 2
         document.getElementById('scanSpecimenID2').onpaste = e => e.preventDefault();
 
         collectionInputValidator(['scanSpecimenID', 'scanSpecimenID2']);
 
         addEventClinicalSpecimenLinkForm2(formData);
-    } 
-    else {//clinical specimen page 1
+    } else {//clinical specimen page 1
         autoTabInputField('accessionID1', 'accessionID2')
         autoTabInputField('accessionID2', 'accessionID3')
         autoTabInputField('accessionID3', 'accessionID4')
 
-
+        // const accessionId1Input = document.getElementById('accessionID1');
+        // const accessionId2Input = document.getElementById('accessionID2');
+        // const accessionId3Input = document.getElementById('accessionID3');
+        // const accessionId4Input = document.getElementById('accessionID4');
         document.getElementById('accessionID2').onpaste = e => e.preventDefault();
         document.getElementById('accessionID4').onpaste = e => e.preventDefault();
 
         numericInputValidator(['accessionID1', 'accessionID2', 'accessionID3', 'accessionID4']);
 
+        // add form validation on user input for accession IDs 3 and 4
+        confirmInputChecker(['accessionID1', 'accessionID2', 'accessionID3', 'accessionID4']);
+        
         addEventClinicalSpecimenLinkForm(formData);
     }
 
@@ -211,3 +215,107 @@ export const specimenTemplate = async (data, formData) => {
     addEventBackToSearch('navBarSearch');
     addEventNavBarParticipantCheckIn();
 }
+
+/**
+ * Adds event listeners to the form fields to make sure matching inputs
+*/
+const confirmInputChecker = () => { 
+    // Todo: Rename variables to be shorter accessionId1InputEl -> accessionId1
+    const accessionId1 = document.getElementById('accessionID1');
+    const accessionId2 = document.getElementById('accessionID2');
+    const accessionId3 = document.getElementById('accessionID3');
+    const accessionId4 = document.getElementById('accessionID4');
+    const accessionId2Error = document.getElementById('accessionId2Error');
+    const accessionId4Error = document.getElementById('accessionId4Error');
+    
+    // Get input fields
+    // get input field values for accession IDs 1 and 2
+    // get input field values for accession IDs 3 and 4
+
+    // LETS START WITH THE FIRST TWO INPUTS
+    // add event listener to accession ID 2 input field using blur event
+    // compare accession ID 2s input value with accession ID 1s input value
+    // if input 2 does not match input 1, display error message on input 2 and add .is-invalid class to input 2 and input 1
+    // - addition: add text error message to only input 2
+    
+    accessionId2.addEventListener('blur', () => { 
+        if (accessionId1.value !== accessionId2.value) {
+            accessionId1.classList.add('is-invalid');
+            accessionId2.classList.add('is-invalid');
+            document.getElementById('accessionId2Error').textContent = 'The blood accession IDs do not match.';
+        } else {
+            accessionId1.classList.remove('is-invalid');
+            accessionId2.classList.remove('is-invalid');
+            document.getElementById('accessionId2Error').textContent = '';
+        }
+    });
+
+    accessionId4.addEventListener('blur', () => { 
+        if (accessionId4.value !== accessionId3.value) {
+            accessionId4.classList.add('is-invalid');
+            accessionId3.classList.add('is-invalid');
+            document.getElementById('accessionId4Error').textContent = 'The urine accession IDs do not match.';
+        } else {
+            accessionId4.classList.remove('is-invalid');
+            accessionId3.classList.remove('is-invalid');
+            document.getElementById('accessionId4Error').textContent = '';
+        }
+    });
+
+    // add blur event handler logic the accession Id inputs for 1 and 2, when user retypes bloor or urine (not reenter input fields)
+    accessionId1.addEventListener('blur', () => { // blur for reenter input 1
+        if (accessionId1.classList.contains('is-invalid')) { // check for invalid-class
+            if (accessionId1.value === accessionId2.value) {
+                accessionId1.classList.remove('is-invalid');
+                accessionId2.classList.remove('is-invalid');
+                document.getElementById('accessionId2Error').textContent = '';
+            }
+        }
+
+        if (accessionId1.value.length > 0 && 
+            accessionId2.value.length > 0 && 
+            accessionId1.value !== accessionId2.value) {
+            accessionId1.classList.add('is-invalid');
+            accessionId2.classList.add('is-invalid');
+            document.getElementById('accessionId2Error').textContent = 'The blood accession IDs do not match.';
+        }
+    });
+
+    accessionId3.addEventListener('blur', () => { // blur for reenter input 1
+        if (accessionId3.classList.contains('is-invalid')) { // check for invalid-class
+            if (accessionId3.value === accessionId4.value) {
+                accessionId3.classList.remove('is-invalid');
+                accessionId4.classList.remove('is-invalid');
+                document.getElementById('accessionId4Error').textContent = '';
+            }
+        }
+        if (accessionId3.value.length > 0 && 
+            accessionId4.value.length > 0 && 
+            accessionId3.value !== accessionId4.value) { 
+            accessionId3.classList.add('is-invalid');
+            accessionId4.classList.add('is-invalid');
+            document.getElementById('accessionId4Error').textContent = 'The urine accession IDs do not match.';
+        }
+    });
+}
+
+
+
+/**
+ * 
+ * @param {Element} accessionInput1 - doc element of input  (Ex. accessionID1)
+ * @param {Element} accessionInput2 - doc element of input  (Ex. accessionID2)
+ * @param {Element} accessionError - accession Error
+ * @param {string} accessionType - blood or urine
+ */
+
+const addAccessionError = (accessionInput1, accessionInput2, accessionError ,accessionType) => { 
+    accessionInput1.classList.add('is-invalid');
+    accessionInput2.classList.add('is-invalid');
+
+    if (accessionError) {
+        accessionError.textContent = `The ${accessionType} accession IDs do not match.`;
+    }
+}
+
+addAccessionError(accessionID1, accessionID2, accessionId2Error ,"blood");

--- a/src/pages/specimen.js
+++ b/src/pages/specimen.js
@@ -26,8 +26,9 @@ export const specimenTemplate = async (data, formData) => {
         </br>
         <div class="row">
             <div class="col">
-                <div class="row">${data['996038075']},<span id='399159511'>${data['399159511']}</span></div>
-                <div class="row">Connect ID: <svg id="connectIdBarCode"></svg></div>
+                <div class="row specimenLinkParticipantInfo"><p><strong>Participant Name: </strong> ${data['996038075']},<span id='399159511'>${data['399159511']}</span></p></div>
+                <div class="row specimenLinkParticipantInfo"><p><strong>Date of Birth:</strong> ${data['564964481']}/${data['795827569']}/${data['544150384']}</span></p></div>
+                <div class="row specimenLinkParticipantInfo"> <p> <strong>Connect ID:</strong> </p> <svg id="connectIdBarCode"></svg></div>
             </div>
         </div>
 

--- a/src/pages/specimen.js
+++ b/src/pages/specimen.js
@@ -1,6 +1,7 @@
 import { addEventBarCodeScanner, collectionSettings, generateBarCode, getWorkflow, removeActiveClass, siteLocations, visitType, getCheckedInVisit, getSiteAcronym, numericInputValidator, getSiteCode, searchSpecimen, collectionInputValidator, addSelectionEventListener, autoTabInputField } from "./../shared.js";
 import { addEventSpecimenLinkForm, addEventClinicalSpecimenLinkForm, addEventClinicalSpecimenLinkForm2, addEventNavBarParticipantCheckIn, addEventBackToSearch } from "./../events.js";
 import { masterSpecimenIDRequirement } from "../tubeValidation.js";
+import { conceptIds } from '../fieldToConceptIdMapping.js';
 
 export const specimenTemplate = async (data, formData) => {
     removeActiveClass('navbar-btn', 'active')
@@ -26,8 +27,8 @@ export const specimenTemplate = async (data, formData) => {
         </br>
         <div class="row">
             <div class="col">
-                <div class="row specimenLinkParticipantInfo"><p><strong>Participant Name: </strong> ${data['996038075']},<span id='399159511'>${data['399159511']}</span></p></div>
-                <div class="row specimenLinkParticipantInfo"><p><strong>Date of Birth:</strong> ${data['564964481']}/${data['795827569']}/${data['544150384']}</span></p></div>
+                <div class="row specimenLinkParticipantInfo"><p><strong>Participant Name: </strong> ${data[conceptIds.lastName]},<span id=${conceptIds.firstName}>${data[conceptIds.firstName]}</span></p></div>
+                <div class="row specimenLinkParticipantInfo"><p><strong>Date of Birth:</strong> ${data[conceptIds.birthMonth]}/${data[conceptIds.birthDay]}/${data[conceptIds.birthYear]}</span></p></div>
                 <div class="row specimenLinkParticipantInfo"> <p> <strong>Connect ID:</strong> </p> <svg id="connectIdBarCode"></svg></div>
             </div>
         </div>

--- a/src/pages/specimen.js
+++ b/src/pages/specimen.js
@@ -196,17 +196,13 @@ export const specimenTemplate = async (data, formData) => {
         autoTabInputField('accessionID2', 'accessionID3')
         autoTabInputField('accessionID3', 'accessionID4')
 
-        // const accessionId1Input = document.getElementById('accessionID1');
-        // const accessionId2Input = document.getElementById('accessionID2');
-        // const accessionId3Input = document.getElementById('accessionID3');
-        // const accessionId4Input = document.getElementById('accessionID4');
         document.getElementById('accessionID2').onpaste = e => e.preventDefault();
         document.getElementById('accessionID4').onpaste = e => e.preventDefault();
 
         numericInputValidator(['accessionID1', 'accessionID2', 'accessionID3', 'accessionID4']);
 
         // add form validation on user input for accession IDs 3 and 4
-        confirmInputChecker(['accessionID1', 'accessionID2', 'accessionID3', 'accessionID4']);
+        checkAccessionMatch(['accessionID1', 'accessionID2', 'accessionID3', 'accessionID4']);
         
         addEventClinicalSpecimenLinkForm(formData);
     }
@@ -217,105 +213,86 @@ export const specimenTemplate = async (data, formData) => {
 }
 
 /**
- * Adds event listeners to the form fields to make sure matching inputs
+ * Adds event listeners to the form fields to make sure accession inputs are checked and have matching values
 */
-const confirmInputChecker = () => { 
-    // Todo: Rename variables to be shorter accessionId1InputEl -> accessionId1
+const checkAccessionMatch = () => { 
     const accessionId1 = document.getElementById('accessionID1');
     const accessionId2 = document.getElementById('accessionID2');
     const accessionId3 = document.getElementById('accessionID3');
     const accessionId4 = document.getElementById('accessionID4');
     const accessionId2Error = document.getElementById('accessionId2Error');
     const accessionId4Error = document.getElementById('accessionId4Error');
-    
-    // Get input fields
-    // get input field values for accession IDs 1 and 2
-    // get input field values for accession IDs 3 and 4
-
-    // LETS START WITH THE FIRST TWO INPUTS
-    // add event listener to accession ID 2 input field using blur event
-    // compare accession ID 2s input value with accession ID 1s input value
-    // if input 2 does not match input 1, display error message on input 2 and add .is-invalid class to input 2 and input 1
-    // - addition: add text error message to only input 2
-    
+        
     accessionId2.addEventListener('blur', () => { 
         if (accessionId1.value !== accessionId2.value) {
-            accessionId1.classList.add('is-invalid');
-            accessionId2.classList.add('is-invalid');
-            document.getElementById('accessionId2Error').textContent = 'The blood accession IDs do not match.';
+            addAccessionError(accessionId1, accessionId2, accessionId2Error, 'blood');
         } else {
-            accessionId1.classList.remove('is-invalid');
-            accessionId2.classList.remove('is-invalid');
-            document.getElementById('accessionId2Error').textContent = '';
+            removeAccessionError(accessionId1, accessionId2, accessionId2Error);
         }
     });
 
     accessionId4.addEventListener('blur', () => { 
         if (accessionId4.value !== accessionId3.value) {
-            accessionId4.classList.add('is-invalid');
-            accessionId3.classList.add('is-invalid');
-            document.getElementById('accessionId4Error').textContent = 'The urine accession IDs do not match.';
+            addAccessionError(accessionId3, accessionId4, accessionId4Error, 'urine');
         } else {
-            accessionId4.classList.remove('is-invalid');
-            accessionId3.classList.remove('is-invalid');
-            document.getElementById('accessionId4Error').textContent = '';
+            removeAccessionError(accessionId3, accessionId4, accessionId4Error);
         }
     });
 
     // add blur event handler logic the accession Id inputs for 1 and 2, when user retypes bloor or urine (not reenter input fields)
-    accessionId1.addEventListener('blur', () => { // blur for reenter input 1
-        if (accessionId1.classList.contains('is-invalid')) { // check for invalid-class
+    accessionId1.addEventListener('blur', () => {
+        if (accessionId1.classList.contains('is-invalid')) {
             if (accessionId1.value === accessionId2.value) {
-                accessionId1.classList.remove('is-invalid');
-                accessionId2.classList.remove('is-invalid');
-                document.getElementById('accessionId2Error').textContent = '';
+                removeAccessionError(accessionId1, accessionId2, accessionId2Error);
             }
         }
 
         if (accessionId1.value.length > 0 && 
             accessionId2.value.length > 0 && 
             accessionId1.value !== accessionId2.value) {
-            accessionId1.classList.add('is-invalid');
-            accessionId2.classList.add('is-invalid');
-            document.getElementById('accessionId2Error').textContent = 'The blood accession IDs do not match.';
+            addAccessionError(accessionId1, accessionId2, accessionId2Error, 'blood');
         }
     });
 
-    accessionId3.addEventListener('blur', () => { // blur for reenter input 1
-        if (accessionId3.classList.contains('is-invalid')) { // check for invalid-class
+    accessionId3.addEventListener('blur', () => {
+        if (accessionId3.classList.contains('is-invalid')) {
             if (accessionId3.value === accessionId4.value) {
-                accessionId3.classList.remove('is-invalid');
-                accessionId4.classList.remove('is-invalid');
-                document.getElementById('accessionId4Error').textContent = '';
+                removeAccessionError(accessionId3, accessionId4, accessionId4Error);
             }
         }
         if (accessionId3.value.length > 0 && 
             accessionId4.value.length > 0 && 
-            accessionId3.value !== accessionId4.value) { 
-            accessionId3.classList.add('is-invalid');
-            accessionId4.classList.add('is-invalid');
-            document.getElementById('accessionId4Error').textContent = 'The urine accession IDs do not match.';
+            accessionId3.value !== accessionId4.value) {
+            addAccessionError(accessionId3, accessionId4, accessionId4Error, 'urine'); 
         }
     });
-}
-
-
+};
 
 /**
- * 
+ * Adds error class ".is-invalid" and error message to the accession input field
  * @param {Element} accessionInput1 - doc element of input  (Ex. accessionID1)
  * @param {Element} accessionInput2 - doc element of input  (Ex. accessionID2)
- * @param {Element} accessionError - accession Error
+ * @param {Element} accessionError - accession for element error text, where the error message will display
  * @param {string} accessionType - blood or urine
  */
-
-const addAccessionError = (accessionInput1, accessionInput2, accessionError ,accessionType) => { 
+const addAccessionError = (accessionInput1, accessionInput2, accessionError, accessionType) => { 
     accessionInput1.classList.add('is-invalid');
     accessionInput2.classList.add('is-invalid');
 
     if (accessionError) {
         accessionError.textContent = `The ${accessionType} accession IDs do not match.`;
     }
-}
+};
 
-addAccessionError(accessionID1, accessionID2, accessionId2Error ,"blood");
+/**
+ * Removes error class ".is-invalid" and error message from the accession input field
+ * @param {Element} accessionInput1 - doc element of input  (Ex. accessionID1)
+ * @param {Element} accessionInput2 - doc element of input  (Ex. accessionID2)
+ * @param {Element} accessionError - accession for element Error
+*/
+const removeAccessionError = (accessionInput1, accessionInput2, accessionError) => { 
+    accessionInput1.classList.remove('is-invalid');
+    accessionInput2.classList.remove('is-invalid');
+
+    if (accessionError) accessionError.textContent = '';
+};

--- a/src/pages/specimen.js
+++ b/src/pages/specimen.js
@@ -1,5 +1,5 @@
-import { addEventBarCodeScanner, collectionSettings, generateBarCode, getWorkflow, removeActiveClass, siteLocations, visitType, getCheckedInVisit, getSiteAcronym, numericInputValidator, getSiteCode, searchSpecimen, collectionInputValidator, addSelectionEventListener, autoTabInputField } from "./../shared.js";
-import { addEventSpecimenLinkForm, addEventClinicalSpecimenLinkForm, addEventClinicalSpecimenLinkForm2, addEventNavBarParticipantCheckIn, addEventBackToSearch } from "./../events.js";
+import { addEventBarCodeScanner, collectionSettings, generateBarCode, getWorkflow, removeActiveClass, siteLocations, visitType, getCheckedInVisit, getSiteAcronym, numericInputValidator, getSiteCode, searchSpecimen, collectionInputValidator, addSelectionEventListener, autoTabInputField, errorMessage, removeAllErrors, removeSingleError } from "./../shared.js";
+import { addEventSpecimenLinkForm, addEventClinicalSpecimenLinkForm, addEventClinicalSpecimenLinkForm2, addEventNavBarParticipantCheckIn, addEventBackToSearch, checkAccessionMatch } from "./../events.js";
 import { masterSpecimenIDRequirement } from "../tubeValidation.js";
 import { conceptIds } from '../fieldToConceptIdMapping.js';
 
@@ -151,7 +151,6 @@ export const specimenTemplate = async (data, formData) => {
             </div>
             <div class="form-group row">
                 <input autocomplete="off" type="text" class="form-control col-md-5 offset-4" placeholder="Re-Enter (scan/type) in Accession ID from Blood Tube" id="accessionID2" maxlength="11"/>
-                <div id="accessionId2Error" class="invalid-feedback col-md-5 offset-4 form-helper-text" style="padding-left:0; "></div>
             </div>
             </br>
             <div class="form-group row">
@@ -162,7 +161,6 @@ export const specimenTemplate = async (data, formData) => {
             </div>
             <div class="form-group row">
                 <input autocomplete="off" type="text" class="form-control col-md-5 offset-4" placeholder="Re-Enter (scan/type) in Accession ID from Urine Tube" id="accessionID4" maxlength="11"/>
-                <div id="accessionId4Error" class="invalid-feedback col-md-5 offset-4 form-helper-text" style="padding-left:0; "></div>
             </div>
             
         <div class="form-group row">
@@ -200,99 +198,12 @@ export const specimenTemplate = async (data, formData) => {
         document.getElementById('accessionID4').onpaste = e => e.preventDefault();
 
         numericInputValidator(['accessionID1', 'accessionID2', 'accessionID3', 'accessionID4']);
-
-        // add form validation on user input for accession IDs 3 and 4
-        checkAccessionMatch(['accessionID1', 'accessionID2', 'accessionID3', 'accessionID4']);
+        checkAccessionMatch();
         
-        addEventClinicalSpecimenLinkForm(formData);
+        addEventClinicalSpecimenLinkForm(data, formData);
     }
 
     generateBarCode('connectIdBarCode', data.Connect_ID);
     addEventBackToSearch('navBarSearch');
     addEventNavBarParticipantCheckIn();
 }
-
-/**
- * Adds event listeners to the form fields to make sure accession inputs are checked and have matching values
-*/
-const checkAccessionMatch = () => { 
-    const accessionId1 = document.getElementById('accessionID1');
-    const accessionId2 = document.getElementById('accessionID2');
-    const accessionId3 = document.getElementById('accessionID3');
-    const accessionId4 = document.getElementById('accessionID4');
-    const accessionId2Error = document.getElementById('accessionId2Error');
-    const accessionId4Error = document.getElementById('accessionId4Error');
-        
-    accessionId2.addEventListener('blur', () => { 
-        if (accessionId1.value !== accessionId2.value) {
-            addAccessionError(accessionId1, accessionId2, accessionId2Error, 'blood');
-        } else {
-            removeAccessionError(accessionId1, accessionId2, accessionId2Error);
-        }
-    });
-
-    accessionId4.addEventListener('blur', () => { 
-        if (accessionId4.value !== accessionId3.value) {
-            addAccessionError(accessionId3, accessionId4, accessionId4Error, 'urine');
-        } else {
-            removeAccessionError(accessionId3, accessionId4, accessionId4Error);
-        }
-    });
-
-    // add blur event handler logic the accession Id inputs for 1 and 2, when user retypes bloor or urine (not reenter input fields)
-    accessionId1.addEventListener('blur', () => {
-        if (accessionId1.classList.contains('is-invalid')) {
-            if (accessionId1.value === accessionId2.value) {
-                removeAccessionError(accessionId1, accessionId2, accessionId2Error);
-            }
-        }
-
-        if (accessionId1.value.length > 0 && 
-            accessionId2.value.length > 0 && 
-            accessionId1.value !== accessionId2.value) {
-            addAccessionError(accessionId1, accessionId2, accessionId2Error, 'blood');
-        }
-    });
-
-    accessionId3.addEventListener('blur', () => {
-        if (accessionId3.classList.contains('is-invalid')) {
-            if (accessionId3.value === accessionId4.value) {
-                removeAccessionError(accessionId3, accessionId4, accessionId4Error);
-            }
-        }
-        if (accessionId3.value.length > 0 && 
-            accessionId4.value.length > 0 && 
-            accessionId3.value !== accessionId4.value) {
-            addAccessionError(accessionId3, accessionId4, accessionId4Error, 'urine'); 
-        }
-    });
-};
-
-/**
- * Adds error class ".is-invalid" and error message to the accession input field
- * @param {Element} accessionInput1 - doc element of input  (Ex. accessionID1)
- * @param {Element} accessionInput2 - doc element of input  (Ex. accessionID2)
- * @param {Element} accessionError - accession for element error text, where the error message will display
- * @param {string} accessionType - blood or urine
- */
-const addAccessionError = (accessionInput1, accessionInput2, accessionError, accessionType) => { 
-    accessionInput1.classList.add('is-invalid');
-    accessionInput2.classList.add('is-invalid');
-
-    if (accessionError) {
-        accessionError.textContent = `The ${accessionType} accession IDs do not match.`;
-    }
-};
-
-/**
- * Removes error class ".is-invalid" and error message from the accession input field
- * @param {Element} accessionInput1 - doc element of input  (Ex. accessionID1)
- * @param {Element} accessionInput2 - doc element of input  (Ex. accessionID2)
- * @param {Element} accessionError - accession for element Error
-*/
-const removeAccessionError = (accessionInput1, accessionInput2, accessionError) => { 
-    accessionInput1.classList.remove('is-invalid');
-    accessionInput2.classList.remove('is-invalid');
-
-    if (accessionError) accessionError.textContent = '';
-};

--- a/src/pages/specimen.js
+++ b/src/pages/specimen.js
@@ -27,7 +27,7 @@ export const specimenTemplate = async (data, formData) => {
         </br>
         <div class="row">
             <div class="col">
-                <div class="row specimenLinkParticipantInfo"><p><strong>Participant Name: </strong> ${data[conceptIds.lastName]},<span id=${conceptIds.firstName}>${data[conceptIds.firstName]}</span></p></div>
+                <div class="row specimenLinkParticipantInfo"><p><strong>Participant Name: </strong> ${data[conceptIds.lastName]},<span id="${conceptIds.firstName}">${data[conceptIds.firstName]}</span></p></div>
                 <div class="row specimenLinkParticipantInfo"><p><strong>Date of Birth:</strong> ${data[conceptIds.birthMonth]}/${data[conceptIds.birthDay]}/${data[conceptIds.birthYear]}</span></p></div>
                 <div class="row specimenLinkParticipantInfo"> <p> <strong>Connect ID:</strong> </p> <svg id="connectIdBarCode"></svg></div>
             </div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -479,3 +479,7 @@ box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
 #appVersion {
     font-size: 0.8rem;
 }
+
+.specimenLinkParticipantInfo {
+    font-size: 1.15rem;
+}


### PR DESCRIPTION
This pull request is related to the following issue:
- https://github.com/episphere/connect/issues/1129

**Issue Requirements:**
- Added warning message to already collected samples at the same timepoint for Research Collection and Clinical Collection
- Added additional text under Specimen Link

**Extra (Outside of issue requirements):**
- Improved input validation before submitting in Specimen Link
- Added blur events before user submits
- Handled bug where user can input a blood accession id, a blood accession id confirm and a urine accession confirm and can proceed to the next modal. This occurs vice-versa too. Added logic to make sure if a partial input is filled that display text appears.