### PR TITLE
Security Code Scanning Alert #17: fix DOM text reinterpreted as html

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -3419,6 +3419,13 @@ export const checkAlertState = (alertState, createBoxSuccessAlertEl, createBoxEr
 
 export const delay = ms => new Promise(res => setTimeout(res, ms));
 
+export const escapeHTML = (str) => {
+    const div = document.createElement('div');
+    div.appendChild(document.createTextNode(str));
+    console.log(div);
+    return div.innerHTML;
+};
+
 export const convertConceptIdToPackageCondition = (packagedCondition, packageConditionConversion) => {
   let listConditions = ''
   if(!packagedCondition) return listConditions
@@ -3451,7 +3458,7 @@ export const checkDuplicateTrackingIdFromDb = async (boxes) => {
         let trackingId = document.getElementById(`${boxId}trackingId`).value;
         let numBoxesShipped = await getNumPages(5, {trackingId});
         if (numBoxesShipped > 0) {
-            isExistingTrackingId = trackingId;
+            isExistingTrackingId = escapeHTML(trackingId);
             break;
         }
     }

--- a/src/shared.js
+++ b/src/shared.js
@@ -3422,7 +3422,6 @@ export const delay = ms => new Promise(res => setTimeout(res, ms));
 export const escapeHTML = (str) => {
     const div = document.createElement('div');
     div.appendChild(document.createTextNode(str));
-    console.log(div);
     return div.innerHTML;
 };
 


### PR DESCRIPTION
### Related to:
- Security code scanning alert: https://github.com/NCI-C4CP/biospecimen/security/code-scanning/17

### Description
- Creates a text node to escape HTML and ensure that the `trackingId` in `checkDuplicateTrackingIdFromDb()` is interpreted as text when passed to the `shippingDuplicateMessage()` function.