### PR TITLE
Issue#1220: Home Mouthwash Receipt Page Changes

### DIFF
--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -268,6 +268,8 @@ const storePackageReceipt = async (data) => {
   } else if (returnedPtInfo.status === "Check Collection ID") {
     triggerErrorModal("Error during kit receipt. Please check the collection ID.");
   } else if (returnedPtInfo.status === "Check collection date, possible invalid entry") {
+    const modalHeaderEl = document.getElementById("modalHeader");
+    const modalBodyEl = document.getElementById("modalBody");
     displayInvalidCollectionDateModal(modalHeaderEl, modalBodyEl, returnedPtInfo.status);
     console.log("error with collection date");
     appState.setState({ lastRequestedCollectionDateTimeStamp: data[conceptIds.collectionDateTimeStamp] });

--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -200,14 +200,14 @@ const storePackageReceipt = async (data) => {
     triggerSuccessModal("Kit Receipted.");
     document.getElementById("showMsg").innerHTML = "";
     document.getElementById("scannedBarcode").value = "";
-    document.getElementById("packageCondition").value = "";
+    document.getElementById("packageCondition").value = defaultPackageCondition;
     document.getElementById("receivePackageComments").value = "";
     document.getElementById("dateReceived").value = getCurrentDate();
     document.getElementById("collectionComments").value = "";
     
     enableCollectionCardFields();
     enableCollectionCheckBox();
-    document.getElementById("packageCondition").setAttribute("data-selected", "[]");
+    document.getElementById("packageCondition").setAttribute("data-selected", `[${defaultPackageCondition}]`);
     if (document.getElementById("collectionId").value) {
       document.getElementById("collectionId").value = "";
       document.getElementById("dateCollectionCard").value = "";
@@ -216,7 +216,7 @@ const storePackageReceipt = async (data) => {
       document.getElementById("collectionComments").value = "";
       enableCollectionCardFields();
       enableCollectionCheckBox();
-      document.getElementById("packageCondition").setAttribute("data-selected", "[]");
+      document.getElementById("packageCondition").setAttribute("data-selected", `[${defaultPackageCondition}]`);
     }
 
     let requestData = {

--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -18,6 +18,8 @@ export const kitsReceiptScreen = async (auth) => {
   formSubmit(); 
 }
 
+const defaultPackageCondition = conceptIds.pkgGoodCondition;
+
 const kitsReceiptTemplate = async (name) => {
   let template = ``;
   template += homeCollectionNavbar();
@@ -44,9 +46,9 @@ const kitsReceiptTemplate = async (name) => {
                   <div class="row form-group">
                       <label class="col-form-label col-md-4" for="packageCondition">Select Package Condition</label>
                        <div style="display:inline-block; max-width:90%;"> 
-                          <select required class="col form-control" id="packageCondition" style="width:100%" multiple="multiple" data-selected="[]">
+                          <select required class="col form-control" id="packageCondition" style="width:100%" multiple="multiple" data-selected="[${defaultPackageCondition}]">
                               <option id="select-dashboard" value="">-- Select Package Condition --</option>
-                              <option id="select-packageGoodCondition" value=${conceptIds.pkgGoodCondition}>Package in good condition</option>
+                              <option selected id="select-packageGoodCondition" value=${conceptIds.pkgGoodCondition}>Package in good condition</option>
                               <option id="select-pkgCrushed" value=${conceptIds.pkgCrushed}>Package Crushed</option>
                               <option id="select-pkgImproperPackaging" value=${conceptIds.pkgImproperPackaging}>Improper Packaging</option>
                               <option id="select-pkgCollectionCupDamaged" value=${conceptIds.pkgCollectionCupDamaged}>Collection Cup Damaged</option>

--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -46,7 +46,7 @@ const kitsReceiptTemplate = async (name) => {
                   <div class="row form-group">
                       <label class="col-form-label col-md-4" for="packageCondition">Select Package Condition</label>
                        <div style="display:inline-block; max-width:90%;"> 
-                          <select required class="col form-control" id="packageCondition" style="width:100%" multiple="multiple" data-selected="[${defaultPackageCondition}]">
+                          <select required class="col form-control" id="packageCondition" style="width:100%" multiple="multiple" data-selected="[${defaultPackageCondition}]" data-initial-value="[${defaultPackageCondition}]">
                               <option id="select-dashboard" value="">-- Select Package Condition --</option>
                               <option selected id="select-packageGoodCondition" value=${conceptIds.pkgGoodCondition}>Package in good condition</option>
                               <option id="select-pkgCrushed" value=${conceptIds.pkgCrushed}>Package Crushed</option>

--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -82,7 +82,7 @@ const kitsReceiptTemplate = async (name) => {
                       </div>
                       <div class="row form-group">
                           <label class="col-form-label col-md-4" for="timeCollectionCard">Enter Collection Time from Collection Card</label>
-                          <input autocomplete="off" class="col-md-8 form-control" type="time" step="1" id="timeCollectionCard">
+                          <input autocomplete="off" class="col-md-8 form-control" type="time" id="timeCollectionCard">
                       </div>
                       <div class="row form-group">
                           <label class="col-form-label col-md-4" for="collectionComments">Comments on Card Returned</label>

--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -139,21 +139,11 @@ const formSubmit = () => {
       e.preventDefault();
       const modalHeaderEl = document.getElementById("modalHeader");
       const modalBodyEl = document.getElementById("modalBody");
-      // const dateReceived = document.getElementById("dateReceived")?.value;
-      // const dateCollectionCard = document.getElementById("dateCollectionCard")?.value;
-
-      // const isValidCollectionDate = dateCollectionCard <= dateReceived;
       const isPackageInfoValid = validatePackageInformation(true);
 
-      // if (!isValidCollectionDate && appState.getState().collectionDateChecked !== true) {
-      //   displayInvalidCollectionDateModal(modalHeaderEl, modalBodyEl);
-      //   console.log("error with collection date");
-      //   appState.setState({ collectionDateChecked: true });
-      //   console.log(appState.getState());
       if (isPackageInfoValid) {
         displaySelectedPackageConditionListModal(modalHeaderEl, modalBodyEl, true);
       } else {
-        // console.log('isPackageInfoValid pressed!');
         displayInvalidPackageInformationModal(modalHeaderEl, modalBodyEl);
       }
   });
@@ -185,7 +175,6 @@ export const confirmKitReceipt = () => {
         kitObj[conceptIds.collectionCardFlag] = true : kitObj[conceptIds.collectionCardFlag] = false;
         kitObj[conceptIds.collectionAddtnlNotes] = document.getElementById('collectionComments').value;
         kitObj["collectionDateChecked"] = kitObj[conceptIds.collectionDateTimeStamp] && appState.getState().lastRequestedCollectionDateTimeStamp === kitObj[conceptIds.collectionDateTimeStamp];
-        console.log("collectionDateChecked", appState.getState().lastRequestedCollectionDateTimeStamp, kitObj[conceptIds.collectionDateTimeStamp], kitObj["collectionDateChecked"]);
       }
       window.removeEventListener("beforeunload", handleBeforeUnload);
       setupLeavingPageMessage();
@@ -271,9 +260,7 @@ const storePackageReceipt = async (data) => {
     const modalHeaderEl = document.getElementById("modalHeader");
     const modalBodyEl = document.getElementById("modalBody");
     displayInvalidCollectionDateModal(modalHeaderEl, modalBodyEl, returnedPtInfo.status);
-    console.log("error with collection date");
     appState.setState({ lastRequestedCollectionDateTimeStamp: data[conceptIds.collectionDateTimeStamp] });
-    console.log(appState.getState());
   } else {
     triggerErrorModal("Error during kit receipt. Please check the tracking number and other fields.");
   }

--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -78,7 +78,7 @@ const kitsReceiptTemplate = async (name) => {
                       </div>
                       <div class="row form-group">
                           <label class="col-form-label col-md-4" for="dateCollectionCard">Enter Collection Date from Collection Card</label>
-                          <input autocomplete="off" class="col-md-8 form-control" type="date" id="dateCollectionCard">
+                          <input autocomplete="off" class="col-md-8 form-control" type="date" id="dateCollectionCard" onkeydown="event.preventDefault()">
                       </div>
                       <div class="row form-group">
                           <label class="col-form-label col-md-4" for="timeCollectionCard">Enter Collection Time from Collection Card</label>

--- a/src/pages/siteCollection/sitePackageReceipt.js
+++ b/src/pages/siteCollection/sitePackageReceipt.js
@@ -500,9 +500,11 @@ const inputChangeList = [
         listenerType: "change",
         onlyKitsReceipt: false,
         customHandler: handlePackageConditionChange,
-        reset: (input) => { 
-            input.value = ""; 
-            input.setAttribute("data-selected", "[]");
+        reset: (input) => {
+            const initialValue = input.getAttribute("data-initial-value");
+            const initialValueString = initialValue?.replace(/\[|\]/g, "");
+            input.value = initialValueString || "";
+            input.setAttribute("data-selected", initialValue || "[]");
         },
     },
     {

--- a/src/pages/siteCollection/sitePackageReceipt.js
+++ b/src/pages/siteCollection/sitePackageReceipt.js
@@ -730,3 +730,27 @@ const handleUnsavedChangesListeners = (hasUnsavedChanges) => {
     toggleClearFormBtnListener(hasUnsavedChanges);
     toggleBeforeUnloadListener(hasUnsavedChanges);
 };
+
+export const displayInvalidCollectionDateModal = (modalHeaderEl, modalBodyEl, errorMessage) => {
+    modalHeaderEl.innerHTML = `
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    `;
+    modalBodyEl.innerHTML = `
+        <div class="row">
+            <div class="col">
+                <div style="display:flex; justify-content:center; margin-bottom:1rem;">
+                <i class="fas fa-exclamation-triangle fa-5x" style="color:#ffc107"></i>
+                </div>
+                <p style="text-align:center; font-size:1.4rem; margin-bottom:1.2rem;">
+                   ${errorMessage}
+                </p>
+            </div>
+        </div>
+        <div class="row" style="display:flex; justify-content:center;">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal" target="_blank">Close</button>
+        </div>
+        </div>
+    `;
+};


### PR DESCRIPTION
Related to:

- https://github.com/episphere/connect/issues/1220

Description

1. Sets the default Package Condition to _Package in good condition_ on page load and after the form is cleared
2. Prevents manual input in the "Enter Collection Date from Collection Card" date picker. BPTL team must use the calendar
3. Removes the requirement to enter seconds in the "Collection Time from Collection Card" time input field.
4. Adds QC checks on the collection date. The collection date must meet the following criteria:
    1. Collection date cannot be later than the Date Received
    2. Collection date cannot be earlier than Date Shipped (<661940160>BioKit_KitShipTm_v1r0)
          1. If these rules are violated, an error message will pop up as a modal stating, "Check collection date, possible invalid entry". The BPTL team can then close the modal and resubmit. If they resubmit without changes, the modal will _not_ appear again. 
          2. This is accomplished by including a `collectionDateChecked` flag in the API request body. This will let the backend know whether this QC check has already been completed and if it can proceed. 