### PR TITLE
Issue#1220 fix changes to home mouthwash receipt page

### DIFF
--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -197,17 +197,8 @@ const storePackageReceipt = async (data) => {
   hideAnimation();
 
   const returnedPtInfo = await processResponse(response);
-  if (returnedPtInfo.status !== "Check collection date, possible invalid entry") {
-    const modalElement = document.getElementById('modalShowMoreData');
-    modalElement.removeAttribute('aria-modal');
-    modalElement.setAttribute('aria-hidden', true);
-    modalElement.classList.remove("show");
-    modalElement.style.display = "none";
-    const backdrop = document.querySelector('.modal-backdrop');
-    backdrop.classList.remove("show");
-    document.body.classList.remove("modal-open");
-  }
   if (returnedPtInfo.status === true) {
+    closeConfirmPackageReceiptModal();
     triggerSuccessModal("Kit Receipted.");
     document.getElementById("showMsg").innerHTML = "";
     document.getElementById("scannedBarcode").value = "";
@@ -289,6 +280,7 @@ const storePackageReceipt = async (data) => {
     }
 
   } else if (returnedPtInfo.status === "Check Collection ID") {
+    closeConfirmPackageReceiptModal();
     triggerErrorModal("Error during kit receipt. Please check the collection ID.");
   } else if (returnedPtInfo.status === "Check collection date, possible invalid entry") {
     const modalHeaderEl = document.getElementById("modalHeader");
@@ -296,9 +288,26 @@ const storePackageReceipt = async (data) => {
     displayInvalidCollectionDateModal(modalHeaderEl, modalBodyEl, returnedPtInfo.status);
     appState.setState({ lastRequestedCollectionDateTimeStamp: data[conceptIds.collectionDateTimeStamp] });
   } else {
+    closeConfirmPackageReceiptModal();
     triggerErrorModal("Error during kit receipt. Please check the tracking number and other fields.");
   }
 };
+
+const closeConfirmPackageReceiptModal = () => {
+  const confirmReceiptBtn = document.getElementById('confirmReceipt');
+  confirmReceiptBtn.blur();
+
+  const modalElement = document.getElementById('modalShowMoreData');
+  modalElement.removeAttribute("aria-modal");
+  modalElement.setAttribute("aria-hidden", true);
+  modalElement.classList.remove("show");
+  modalElement.style.display = "none";
+
+  const backdrop = document.querySelector(".modal-backdrop");
+  backdrop.classList.remove("show");
+
+  document.body.classList.remove("modal-open");
+}
 
 const enableCollectionCardFields = () => {
     document.getElementById('collectionId').disabled = false;

--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -197,6 +197,16 @@ const storePackageReceipt = async (data) => {
   hideAnimation();
 
   const returnedPtInfo = await processResponse(response);
+  if (returnedPtInfo.status !== "Check collection date, possible invalid entry") {
+    const modalElement = document.getElementById('modalShowMoreData');
+    modalElement.removeAttribute('aria-modal');
+    modalElement.setAttribute('aria-hidden', true);
+    modalElement.classList.remove("show");
+    modalElement.style.display = "none";
+    const backdrop = document.querySelector('.modal-backdrop');
+    backdrop.classList.remove("show");
+    document.body.classList.remove("modal-open");
+  }
   if (returnedPtInfo.status === true) {
     triggerSuccessModal("Kit Receipted.");
     document.getElementById("showMsg").innerHTML = "";

--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -168,7 +168,7 @@ export const confirmKitReceipt = () => {
         const dateCollectionCard = document.getElementById('dateCollectionCard').value;
         const timeCollectionCard = document.getElementById('timeCollectionCard').value;
         if(dateCollectionCard && timeCollectionCard) {
-          kitObj[conceptIds.collectionDateTimeStamp] = dateCollectionCard + 'T' + timeCollectionCard;
+          kitObj[conceptIds.collectionDateTimeStamp] = dateCollectionCard + 'T' + timeCollectionCard + ':00';
         }
         
         document.getElementById('collectionCheckBox').checked === true ? 

--- a/src/pages/siteCollection/sitePackageReceipt.js
+++ b/src/pages/siteCollection/sitePackageReceipt.js
@@ -666,7 +666,7 @@ const displayConfirmPackageReceiptModal = (modalHeaderEl,modalBodyEl) => {
             <span>Confirm package receipt</span>
             <br >
             <div style="display:inline-block;">
-                <button type="submit" class="btn btn-primary" data-dismiss="modal" id="confirmReceipt" target="_blank">Confirm</button>
+                <button type="submit" class="btn btn-primary" id="confirmReceipt" target="_blank">Confirm</button>
                 <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank">Cancel</button>
             </div>
         </div>


### PR DESCRIPTION
Related to:

- https://github.com/episphere/connect/issues/1220

Description

1. Adds ":00" to Collection timestamp
2. Fixes "Check collection date" modal display
    1. the `data-dismiss="modal"` attribute on the `#confirmReceipt` button was closing the modal and making it so the new modal did not appear. These changes remove that attribute and programmatically close the modal in the instances when the new "Check collection date" modal would not appear