### PR TITLE
Issue#1220 remove modal-backdrop element when closing modal

### DIFF
--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -304,7 +304,7 @@ const closeConfirmPackageReceiptModal = () => {
   modalElement.style.display = "none";
 
   const backdrop = document.querySelector(".modal-backdrop");
-  backdrop.classList.remove("show");
+  backdrop.remove();
 
   document.body.classList.remove("modal-open");
 }


### PR DESCRIPTION
Related to:

- https://github.com/episphere/connect/issues/1220

Description

1. Removes the `.modal-backdrop` div from the DOM, allowing BPTL to interact with the page after closing the Confirm Package Receipt modal.