### PR TITLE
Fix: close Site Package Receipt confirmation modal on 'Confirm' button click

### DIFF
--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -293,7 +293,7 @@ const storePackageReceipt = async (data) => {
   }
 };
 
-const closeConfirmPackageReceiptModal = () => {
+export const closeConfirmPackageReceiptModal = () => {
   const confirmReceiptBtn = document.getElementById('confirmReceipt');
   confirmReceiptBtn.blur();
 

--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -293,7 +293,7 @@ const storePackageReceipt = async (data) => {
   }
 };
 
-export const closeConfirmPackageReceiptModal = () => {
+const closeConfirmPackageReceiptModal = () => {
   const confirmReceiptBtn = document.getElementById('confirmReceipt');
   confirmReceiptBtn.blur();
 

--- a/src/pages/siteCollection/sitePackageReceipt.js
+++ b/src/pages/siteCollection/sitePackageReceipt.js
@@ -3,7 +3,7 @@ import { nonUserNavBar } from "../../navbar.js";
 import { siteCollectionNavbar } from "./siteCollectionNavbar.js";
 import { activeSiteCollectionNavbar } from "./activeSiteCollectionNavbar.js";
 import { conceptIds as fieldMapping, packageConditionConversion } from "../../fieldToConceptIdMapping.js";
-import { confirmKitReceipt } from "../homeCollection/kitsReceipt.js";
+import { closeConfirmPackageReceiptModal, confirmKitReceipt } from "../homeCollection/kitsReceipt.js";
 
 let hasUnsavedChanges = false;
 
@@ -117,7 +117,8 @@ const confirmPackageReceipt = () => {
   const confirmReceiptEle = document.getElementById('confirmReceipt');
   if (confirmReceiptEle) {
       confirmReceiptEle.addEventListener('click',  async () => { 
-          try {
+        closeConfirmPackageReceiptModal();
+        try {
               let receiptedPackageObj = {};
               let packageConditions = [];
               const scannedBarcode = document.getElementById('scannedBarcode').value.trim();

--- a/src/pages/siteCollection/sitePackageReceipt.js
+++ b/src/pages/siteCollection/sitePackageReceipt.js
@@ -3,7 +3,7 @@ import { nonUserNavBar } from "../../navbar.js";
 import { siteCollectionNavbar } from "./siteCollectionNavbar.js";
 import { activeSiteCollectionNavbar } from "./activeSiteCollectionNavbar.js";
 import { conceptIds as fieldMapping, packageConditionConversion } from "../../fieldToConceptIdMapping.js";
-import { closeConfirmPackageReceiptModal, confirmKitReceipt } from "../homeCollection/kitsReceipt.js";
+import { confirmKitReceipt } from "../homeCollection/kitsReceipt.js";
 
 let hasUnsavedChanges = false;
 
@@ -117,7 +117,6 @@ const confirmPackageReceipt = () => {
   const confirmReceiptEle = document.getElementById('confirmReceipt');
   if (confirmReceiptEle) {
       confirmReceiptEle.addEventListener('click',  async () => { 
-        closeConfirmPackageReceiptModal();
         try {
               let receiptedPackageObj = {};
               let packageConditions = [];
@@ -655,7 +654,7 @@ export const displaySelectedPackageConditionListModal = (modalHeaderEl, modalBod
     clickConfirmPackageConditionListButton(modalHeaderEl,modalBodyEl, isKitReceipt);
 }
 
-const displayConfirmPackageReceiptModal = (modalHeaderEl,modalBodyEl) => {
+const displayConfirmPackageReceiptModal = (modalHeaderEl,modalBodyEl, isKitReceipt) => {
     modalHeaderEl.innerHTML = `
         <h5>Confirmation</h5>
             <button type="button" class="close" data-dismiss="modal" aria-label="Close">
@@ -667,7 +666,7 @@ const displayConfirmPackageReceiptModal = (modalHeaderEl,modalBodyEl) => {
             <span>Confirm package receipt</span>
             <br >
             <div style="display:inline-block;">
-                <button type="submit" class="btn btn-primary" id="confirmReceipt" target="_blank">Confirm</button>
+                <button type="submit" class="btn btn-primary" ${isKitReceipt ? "" : "data-dismiss=\"modal\""} id="confirmReceipt" target="_blank">Confirm</button>
                 <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank">Cancel</button>
             </div>
         </div>
@@ -688,7 +687,7 @@ const displaySelectedPackageConditionList = (parseSelectPackageConditionsList) =
 const clickConfirmPackageConditionListButton = (modalHeaderEl, modalBodyEl, isKitReceipt) => {
     const confirmPackageConditionButtondocument = document.getElementById("confirmPackageConditionButton");
     confirmPackageConditionButtondocument.addEventListener("click", () => {
-        displayConfirmPackageReceiptModal(modalHeaderEl,modalBodyEl);
+        displayConfirmPackageReceiptModal(modalHeaderEl,modalBodyEl, isKitReceipt);
         if (isKitReceipt) { 
             confirmKitReceipt(); 
         } else { 

--- a/src/pages/siteCollection/sitePackageReceipt.js
+++ b/src/pages/siteCollection/sitePackageReceipt.js
@@ -117,7 +117,7 @@ const confirmPackageReceipt = () => {
   const confirmReceiptEle = document.getElementById('confirmReceipt');
   if (confirmReceiptEle) {
       confirmReceiptEle.addEventListener('click',  async () => { 
-        try {
+          try {
               let receiptedPackageObj = {};
               let packageConditions = [];
               const scannedBarcode = document.getElementById('scannedBarcode').value.trim();


### PR DESCRIPTION
### Resolving issue related to: https://github.com/episphere/connect/issues/1220

Issue reported by Schwartz, Erin on 05/01/25 12:57 PM:

> BPTL just reported an issue with receipting blood/urine boxes from the sites, which was not updated as part of this release. It appears that after the click "Confirm" on the modal shown below, the modal pops up again (almost instantly) and when they click "Confirm" nothing happens, clicking "Cancel" makes the modal go away.

Cause:
- `displaySelectedPackageConditionListModal()` is a shared function used on both the Kit Receipt and Site Package Receipt pages. This function invokes `clickConfirmPackageConditionListButton()`, which then calls `displayConfirmPackageReceiptModal()`.
- In #804, the `data-dismiss="modal"` attribute was removed from `displayConfirmPackageReceiptModal()` to display the "Check collection date" warning modal. This affects how the Confirm Package Receipt modal closes.

Resolution:
- On the Kit Receipt page, the modal is closed manually using DOM manipulation; however, it seems preferable to use bootstrap's built-in functionality with the `data-dismiss="modal"` attribute when possible. 
- **As a result, the Site Package Receipt page now includes the `data-dismiss="modal"` attribute, as it did before the April release. It will only be removed from the Kit Receipt page.**