### PR TITLE
Fix: Programmatically open modal, add data-dismiss attribute back

### DIFF
--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -1,6 +1,6 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
 
-const appVersion = "v25.4.1";
+const appVersion = "v25.4.2";
 workbox.setConfig({debug: false});
 const { registerRoute } = workbox.routing;
 const { CacheFirst, NetworkFirst } = workbox.strategies;

--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -198,7 +198,6 @@ const storePackageReceipt = async (data) => {
 
   const returnedPtInfo = await processResponse(response);
   if (returnedPtInfo.status === true) {
-    closeConfirmPackageReceiptModal();
     triggerSuccessModal("Kit Receipted.");
     document.getElementById("showMsg").innerHTML = "";
     document.getElementById("scannedBarcode").value = "";
@@ -280,33 +279,31 @@ const storePackageReceipt = async (data) => {
     }
 
   } else if (returnedPtInfo.status === "Check Collection ID") {
-    closeConfirmPackageReceiptModal();
     triggerErrorModal("Error during kit receipt. Please check the collection ID.");
   } else if (returnedPtInfo.status === "Check collection date, possible invalid entry") {
     const modalHeaderEl = document.getElementById("modalHeader");
     const modalBodyEl = document.getElementById("modalBody");
+
+    openModal();
     displayInvalidCollectionDateModal(modalHeaderEl, modalBodyEl, returnedPtInfo.status);
     appState.setState({ lastRequestedCollectionDateTimeStamp: data[conceptIds.collectionDateTimeStamp] });
   } else {
-    closeConfirmPackageReceiptModal();
     triggerErrorModal("Error during kit receipt. Please check the tracking number and other fields.");
   }
 };
 
-const closeConfirmPackageReceiptModal = () => {
-  const confirmReceiptBtn = document.getElementById('confirmReceipt');
-  confirmReceiptBtn.blur();
+const openModal = () => {
+  const openModalButton = document.createElement('button');
 
-  const modalElement = document.getElementById('modalShowMoreData');
-  modalElement.removeAttribute("aria-modal");
-  modalElement.setAttribute("aria-hidden", true);
-  modalElement.classList.remove("show");
-  modalElement.style.display = "none";
+  openModalButton.style.display = 'none';
+  openModalButton.setAttribute('data-target', '#modalShowMoreData');
+  openModalButton.setAttribute('data-toggle', 'modal');
+  openModalButton.id = 'openShowMoreDataModalButton';
 
-  const backdrop = document.querySelector(".modal-backdrop");
-  backdrop?.remove();
+  document.body.appendChild(openModalButton);
+  document.getElementById('openShowMoreDataModalButton').click();
 
-  document.body.classList.remove("modal-open");
+  openModalButton.remove();
 }
 
 const enableCollectionCardFields = () => {

--- a/src/pages/siteCollection/sitePackageReceipt.js
+++ b/src/pages/siteCollection/sitePackageReceipt.js
@@ -666,7 +666,7 @@ const displayConfirmPackageReceiptModal = (modalHeaderEl,modalBodyEl, isKitRecei
             <span>Confirm package receipt</span>
             <br >
             <div style="display:inline-block;">
-                <button type="submit" class="btn btn-primary" ${isKitReceipt ? "" : "data-dismiss=\"modal\""} id="confirmReceipt" target="_blank">Confirm</button>
+                <button type="submit" class="btn btn-primary" data-dismiss="modal" id="confirmReceipt" target="_blank">Confirm</button>
                 <button type="button" class="btn btn-danger" data-dismiss="modal" target="_blank">Cancel</button>
             </div>
         </div>
@@ -750,7 +750,6 @@ export const displayInvalidCollectionDateModal = (modalHeaderEl, modalBodyEl, er
         </div>
         <div class="row" style="display:flex; justify-content:center;">
             <button type="button" class="btn btn-secondary" data-dismiss="modal" target="_blank">Close</button>
-        </div>
         </div>
     `;
 };


### PR DESCRIPTION
### Resolving issue related to: https://github.com/episphere/connect/issues/1220

Issue reported by Schwartz, Erin on 05/02/25 12:23 PM:

> BPTL just reported that they are experiencing a different issue in Stage, they need to click 'Save' 2x during Home Mouthwash Kit Receipt.

Further Detail:
- This issue appears to be occurring on the second attempt to save. Receiving the kit the first time functions properly, but the second attempt requires users to click the 'Save' button twice.

Cause:
- `closeConfirmPackageReceiptModal()` programmatically closes the Confirm Package Receipt modal. This is used in cases when the "Check collection date" warning modal should _not_ be displayed after the user dismisses the Confirm Package Receipt modal.
- The Confirm Package Receipt modal does not appear to close properly, requiring the 'Save' button to be clicked twice on a subsequent attempt to save.

Resolution:
- Use bootstrap's built-in functionality with the `data-dismiss="modal"` attribute to close the Confirm Package Receipt modal. 
- Programmatically open the  "Check collection date" warning modal. When this modal closes, it will also use the `data-dismiss="modal"` attribute.