### PR TITLE
1303 -  Update"No labels to print" banner to consider replacement kit labels

### DIFF
--- a/src/pages/homeCollection/printLabels.js
+++ b/src/pages/homeCollection/printLabels.js
@@ -61,7 +61,7 @@ const printLabelsTemplate = (name) => {
   document.getElementById("navbarNavAltMarkup").innerHTML = nonUserNavBar(name);
   contentBody.innerHTML = template;
   activeHomeCollectionNavbar();
-  if (appState.getState().totalAddressesLength === 0) triggerErrorModal('No labels to print');
+  if (appState.getState().totalAddressesLength === 0 && !appState.getState().totalReplacementAddressesLength) triggerErrorModal('No labels to print');
   generateParticipantCsvGetter(name);
   generateParticipantReplacementCsvGetter(name);
 


### PR DESCRIPTION
"No labels to print" banner will no longer display on print addresses page if there are no initial kit addresses to print but there are replacement kit addresses to print. ([1303](https://github.com/episphere/connect/issues/1303))