### PR TITLE
Remove Heparin tube from Research Dashboard Collection Data Entry

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -3221,6 +3221,11 @@ export const getSiteTubesLists = (biospecimenData) => {
     if (+new Date() >= +new Date('2024-02-20T00:00:00.000')) {
         siteTubesList = siteTubesList.filter((tube) => tube.id !== '0005');
     }
+
+    if (getWorkflow() === 'research') {
+        siteTubesList = siteTubesList.filter((tube) => !['0003'].includes(tube.id)); // removes heparin tube (0003) from collection data entry
+    }
+
     return siteTubesList;
 }
 


### PR DESCRIPTION
The pull request is related to the following:
- https://github.com/episphere/connect/issues/1271

Changes:
- Remove Heparin Tube from Research Dashboard's Collection Data Entry screen

Code Changes:
- Added filter to remove Heparin Tube for research workflow only

---
Screenshots using a test account in dev 

<img src="https://github.com/user-attachments/assets/07bdd6b8-1e76-40bc-b17f-0c6f88a80eab" width="400" />
<img src="https://github.com/user-attachments/assets/7f9c685f-a144-47fe-8a03-d530f9d24afa" width="400" />

