### PR TITLE
1203 Updates

### DIFF
--- a/src/pages/finalize.js
+++ b/src/pages/finalize.js
@@ -49,7 +49,7 @@ export const finalizeTemplate = (participantData, specimenData, bptlCollectionFl
             </div>
             ${specimenData[conceptIds.collection.selectedVisit] ? `
                 <div class="ml-auto form-group">
-                    Visit: ${visitType.filter(visit => visit.concept == specimenData[conceptIds.collection.selectedVisit])[0].visitType}
+                    Visit: ${visitType.filter(visit => visit.concept == specimenData[conceptIds.collection.selectedVisit])[0]?.visitType}
                 </div>
             ` : ``
             }
@@ -70,25 +70,25 @@ export const finalizeTemplate = (participantData, specimenData, bptlCollectionFl
                 </thead>
                 <tbody>`
                 const siteTubesList = getSiteTubesLists(specimenData)
-                siteTubesList.forEach((obj) => {
+                siteTubesList?.forEach((obj) => {
 
-                    const notCollectedOptions = siteTubesList.filter(tube => tube.concept === obj.concept)[0].tubeNotCollectedOptions;
+                    const notCollectedOptions = siteTubesList.filter(tube => tube.concept === obj.concept)[0]?.tubeNotCollectedOptions;
                     let deviationSelections = [];
 
                     if(obj.deviationOptions) {
                         obj.deviationOptions.forEach(option => {
-                            if(specimenData[obj.concept][conceptIds.collection.tube.deviation][option.concept] === conceptIds.yes) deviationSelections.push(option.label);
+                            if(specimenData[obj.concept]?.[conceptIds.collection.tube.deviation]?.[option.concept] === conceptIds.yes) deviationSelections.push(option.label);
                         });
                     }
                     template += `
                         <tr style="vertical-align: top;">
                             <td>${obj.specimenType}</td>
-                            <td>${obj.collectionChkBox === true ? `${specimenData[`${obj.concept}`][conceptIds.collection.tube.isCollected] === conceptIds.yes ? '<i class="fas fa-check"></i>' : '<i class="fas fa-times"></i>'}` : ``}</td>
-                            ${getWorkflow() === 'research' ? `<td>${specimenData[`${obj.concept}`][conceptIds.collection.tube.selectReasonNotCollected] ? notCollectedOptions.filter(option => option.concept == specimenData[`${obj.concept}`][conceptIds.collection.tube.selectReasonNotCollected])[0].label : ''}</td>` : ''}
-                            <td>${specimenData[`${obj.concept}`][conceptIds.collection.tube.isCollected] === conceptIds.yes && specimenData[`${obj.concept}`][conceptIds.collection.tube.scannedId] ? `${specimenData[`${obj.concept}`][conceptIds.collection.tube.scannedId]}` : '' }</td>
-                            <td>${obj.deviationChkBox === true ? `${specimenData[`${obj.concept}`][conceptIds.collection.tube.isDeviated] === conceptIds.yes ? 'Yes' : 'No'}`: ``}</td>
+                            <td>${obj.collectionChkBox === true ? `${specimenData[`${obj.concept}`]?.[conceptIds.collection.tube.isCollected] === conceptIds.yes ? '<i class="fas fa-check"></i>' : '<i class="fas fa-times"></i>'}` : ``}</td>
+                            ${getWorkflow() === 'research' ? `<td>${specimenData[`${obj.concept}`]?.[conceptIds.collection.tube.selectReasonNotCollected] ? notCollectedOptions.filter(option => option.concept == specimenData[`${obj.concept}`]?.[conceptIds.collection.tube.selectReasonNotCollected])?.[0]?.label : ''}</td>` : ''}
+                            <td>${specimenData[`${obj.concept}`]?.[conceptIds.collection.tube.isCollected] === conceptIds.yes && specimenData[`${obj.concept}`]?.[conceptIds.collection.tube.scannedId] ? `${specimenData[`${obj.concept}`]?.[conceptIds.collection.tube.scannedId]}` : '' }</td>
+                            <td>${obj.deviationChkBox === true ? `${specimenData[`${obj.concept}`]?.[conceptIds.collection.tube.isDeviated] === conceptIds.yes ? 'Yes' : 'No'}`: ``}</td>
                             <td class="deviation-type-width">${deviationSelections ? getDeviationSelections(deviationSelections) : ''}</td>
-                            <td class="deviation-comments-width">${specimenData[`${obj.concept}`][conceptIds.collection.tube.deviationComments] ? specimenData[`${obj.concept}`][conceptIds.collection.tube.deviationComments] : specimenData[`${obj.concept}`][conceptIds.collection.tube.optionalNotCollectedDetails] ? specimenData[`${obj.concept}`][conceptIds.collection.tube.optionalNotCollectedDetails] : ''}</td>
+                            <td class="deviation-comments-width">${specimenData[`${obj.concept}`]?.[conceptIds.collection.tube.deviationComments] ? specimenData[`${obj.concept}`][conceptIds.collection.tube.deviationComments] : specimenData[`${obj.concept}`]?.[conceptIds.collection.tube.optionalNotCollectedDetails] ? specimenData[`${obj.concept}`][conceptIds.collection.tube.optionalNotCollectedDetails] : ''}</td>
                         </tr>
                     `
                 });

--- a/src/pages/siteCollection/collectionIdSearch.js
+++ b/src/pages/siteCollection/collectionIdSearch.js
@@ -71,13 +71,19 @@ const collectionIdSearchBPTL = () => {
             
             if (!validateSpecimenAndParticipantResponse(specimenData, participantData, isBPTL)) return;
             
-            localStorage.setItem('workflow', specimenData[fieldToConceptIdMapping.collectionType] === fieldToConceptIdMapping.clinical ? `clinical` : `research`); // Note: this has been in the codebase. Not sure it's necessary.
+            try {
+                localStorage.setItem('workflow', specimenData[fieldToConceptIdMapping.collectionType] === fieldToConceptIdMapping.clinical ? `clinical` : `research`); // Note: this has been in the codebase. Not sure it's necessary.
 
-            // Boolean flag: true; is passed down to finalizeTemplate & to distinguish collection id search from bptl and biospecimen."
-            finalizeTemplate(participantData, specimenData, true);
+                // Boolean flag: true; is passed down to finalizeTemplate & to distinguish collection id search from bptl and biospecimen."
+                finalizeTemplate(participantData, specimenData, true);
+            } catch (err) {
+                console.error('Error in displaying finalize screen for collection %s', masterSpecimenId, err);
+                showNotifications({ title: 'Error: Display error', body: `Error: Unable to display finalize screen for collection ${masterSpecimenId}.` });
+            }
+            
 
-        } catch {
-            console.error(`Error in collectionIdSearchBPTL: Couldn't find collection ${masterSpecimenId}.`);
+        } catch (err) {
+            console.error(`Error in collectionIdSearchBPTL: Couldn't find collection ${masterSpecimenId}.`, err);
             showNotifications({ title: 'Error: Not found', body: `Error: Couldn't find collection ${masterSpecimenId}.` });
         } finally {
             hideAnimation();

--- a/src/shared.js
+++ b/src/shared.js
@@ -3218,7 +3218,7 @@ export const getSiteTubesLists = (biospecimenData) => {
     const subSiteLocation = siteLocations[dashboardType]?.[siteAcronym] ? siteLocations[dashboardType]?.[siteAcronym]?.filter(dt => dt.concept === biospecimenData[conceptIds.collectionLocation])[0]?.location : undefined;
     let siteTubesList = siteSpecificTubeRequirements[siteAcronym]?.[dashboardType]?.[subSiteLocation] ? siteSpecificTubeRequirements[siteAcronym]?.[dashboardType]?.[subSiteLocation] : siteSpecificTubeRequirements[siteAcronym]?.[dashboardType];
     //After March 1, 2024 the ACD tubes will expire and no longer be collected
-    if (+new Date() >= +new Date('2024-02-20T00:00:00.000')) {
+    if (siteTubesList && +new Date() >= +new Date('2024-02-20T00:00:00.000')) {
         siteTubesList = siteTubesList.filter((tube) => tube.id !== '0005');
     }
     return siteTubesList;


### PR DESCRIPTION
Added more robust error messaging and null checking to collection ID search process.

Rationale: Issue [1203](https://github.com/episphere/connect/issues/1203) reports an issue viewing collections which were received before 11/3/2023. There is no date cutoff in the code, and the collection and its corresponding participant both exist. However, the error messaging for the Collection ID Search workflow currently assumes that any errors are the result of failing to find a matching collection ID, resulting in that error message being displayed if there are any other errors within its wrapping try/catch block, completely swallowing any potential errors from calling `finalizeTemplate`.

Changes:

finalize.js: 
Changes to finalizeTemplate:
* Ensures that a visit matching the specimen data is found before trying to read its visitType property.
* Added null checking throughout when reading nested properties of the specimenData object. While specimenData exists, there is some possibility that the deeply nested objects referenced may not exist for older data, which is a likely cause of 1203.

collectionIdSearch.js:
* The try/catch block around finding collection IDs now logs out the error received to the console, so it is no longer swallowed.
* The finalizeTemplate portion of the functionality is now wrapped in its own try/catch block with informative error message display so that if it is the source of the error it will be more clearly displayed and will not be incorrectly attributed to the specimen not being found.

shared.js: getSiteTubesList ensures that site tubes exists before attempting to filter the ACD tube out of the available tubes. This was called as a part of finalize.js and has been updated to ensure it is not a source of error.