### PR TITLE
Issue #1307: allow tabbing from Collection Date field

### DIFF
--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -80,7 +80,7 @@ const kitsReceiptTemplate = async (name) => {
                       </div>
                       <div class="row form-group">
                           <label class="col-form-label col-md-4" for="dateCollectionCard">Enter Collection Date from Collection Card</label>
-                          <input autocomplete="off" class="col-md-8 form-control" type="date" id="dateCollectionCard" onkeydown="event.preventDefault()">
+                          <input autocomplete="off" class="col-md-8 form-control" type="date" id="dateCollectionCard">
                       </div>
                       <div class="row form-group">
                           <label class="col-form-label col-md-4" for="timeCollectionCard">Enter Collection Time from Collection Card</label>
@@ -118,6 +118,17 @@ template += `<div class="modal fade" id="modalShowMoreData" data-keyboard="false
   activeHomeCollectionNavbar();
   checkTrackingNumberSource();
   performCollectionIdcheck();
+  preventManualEntry();
+};
+
+const preventManualEntry = () => {
+  document.getElementById("dateCollectionCard").addEventListener("keydown", (event) => {
+    const key = event.key;
+    const code = event.code;
+    if (key !== "Tab" && key !== "Enter" && code !== "Space") {
+      event.preventDefault();
+    }
+  });
 };
 
 const performCollectionIdcheck = () => {

--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -123,8 +123,7 @@ template += `<div class="modal fade" id="modalShowMoreData" data-keyboard="false
 
 const preventManualEntry = () => {
   document.getElementById("dateCollectionCard").addEventListener("keydown", (event) => {
-    const key = event.key;
-    const code = event.code;
+    const { key, code } = event;
     if (key !== "Tab" && key !== "Enter" && code !== "Space") {
       event.preventDefault();
     }


### PR DESCRIPTION
### Related Issue:
- https://github.com/episphere/connect/issues/1307

Changes:
- Allows BPTL to tab through the fields on the Home Mouthwash Kit Receipt page while preventing entry into the Collection Date field using anything other than the calendar picker (requirement from https://github.com/episphere/connect/issues/1220).  

Code Changes:

- Removed the `onkeydown` attribute from the Collection Date input field
- Added an EventListener to the Collection Date input field on `keydown`
   -  If the key clicked is not the Tab key, the Enter key, or the Spacebar, set `event.preventDefault()`
         - Tab key: move to the next interactive element (tabs through the form inputs)
         - Enter key: activate elements (opens the calendar picker, clicks buttons)
         - Spacebar: activates buttons (opens the calendar picker)