### PR TITLE
Prevent repeated notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ static/images/.DS_Store
 /tmp
 .hintrc
 .eslintrc.json
+eslint.config.js
 scratch.js
 node_modules/
 package.json

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -1,6 +1,6 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
 
-const appVersion = "v25.4.2";
+const appVersion = "v25.5.0";
 workbox.setConfig({debug: false});
 const { registerRoute } = workbox.routing;
 const { CacheFirst, NetworkFirst } = workbox.strategies;

--- a/src/pages/homeCollection/kitShipment.js
+++ b/src/pages/homeCollection/kitShipment.js
@@ -86,9 +86,9 @@ const saveResponse = (uniqueKitID) => {
   let data = {};
   data[conceptIds.uniqueKitID] = uniqueKitID;
   if (saveResponseBtn) {
-    saveResponseBtn.addEventListener("click", (e) => {
+    saveResponseBtn.addEventListener("click", async () => {
       data[conceptIds.shippedDateTime] = convertDateReceivedinISO(document.getElementById("inputDate").value);
-      setShippedResponse(data);
+      await setShippedResponse(data);
     });
   }
 };
@@ -138,16 +138,8 @@ const setShippedResponse = async (data) => {
         firstName: returnedPtInfo.ptName || "User",
       },
     };
-
-    try {
-      await sendInstantNotification(requestData);
-    } catch (e) {
-      console.error(`Error sending email to user ${returnedPtInfo.prefEmail}`, e);
-      throw new Error(`Error sending email to user ${returnedPtInfo.prefEmail}: ${e.message}`);
-    }
     
-    return true;
-
+    await sendInstantNotification(requestData);
   } else {
     triggerErrorModal('Error in shipping: Please check the tracking number.');
   }

--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -162,7 +162,7 @@ const formSubmit = () => {
 export const confirmKitReceipt = () => {
   const confirmReceiptBtn = document.getElementById('confirmReceipt');
   if (confirmReceiptBtn) {
-    confirmReceiptBtn.addEventListener('click',  () => {
+    confirmReceiptBtn.addEventListener('click',  async () => {
       let kitObj = {};
       let packageConditions = [];
       const scannedBarcode = document.getElementById('scannedBarcode').value.trim();
@@ -188,10 +188,10 @@ export const confirmKitReceipt = () => {
       }
       window.removeEventListener("beforeunload", handleBeforeUnload);
       setupLeavingPageMessage();
-      storePackageReceipt(kitObj);
-    })
+      await storePackageReceipt(kitObj);
+    });
   }
-}
+};
 
 const storePackageReceipt = async (data) => {
   showAnimation();
@@ -278,16 +278,9 @@ const storePackageReceipt = async (data) => {
           requestData.category = "Mouthwash Home Collection Acknowledgement";
         }
       }
-      
     }
 
-    try {
-      await sendInstantNotification(requestData);
-    } catch (e) {
-      console.error(`Error sending email to user ${returnedPtInfo.prefEmail}.`, e);
-      throw new Error(`Error sending email to user ${returnedPtInfo.prefEmail}: ${e.message}`);
-    }
-
+    await sendInstantNotification(requestData);
   } else if (returnedPtInfo.status === "Check Collection ID") {
     triggerErrorModal("Error during kit receipt. Please check the collection ID.");
   } else if (returnedPtInfo.status === "Check collection date, possible invalid entry") {

--- a/src/shared.js
+++ b/src/shared.js
@@ -152,22 +152,20 @@ export const getUserProfile = async (uid) => {
     return await response.json();
 }
 
-export const sendClientEmail = async (array) => {
-    const idToken = await getIdToken();
-    let requestObj = {
-        method: "POST",
-        headers:{
-            Authorization:"Bearer "+idToken,
-            "Content-Type": "application/json"
-        },
-        body: JSON.stringify(array)
-    }
-    const response = await fetch(`${api}api=sendClientEmail`, requestObj);
-    
-    return response;
-}
-
 export const sendInstantNotification = async (requestData) => {
+  const catPtStr = `${requestData.category}- ${requestData.connectId}`;
+  const isNotificationHandled = appState.getState().handledNotifications?.[catPtStr];
+  if (isNotificationHandled) return true;
+
+
+  appState.setState((prevState) => ({
+    ...prevState,
+    handledNotifications: {
+      ...prevState.handledNotifications,
+      [catPtStr]: true,
+    },
+  }));
+
   const idToken = await getIdToken();
   const requestObj = {
     method: "POST",
@@ -177,13 +175,26 @@ export const sendInstantNotification = async (requestData) => {
     },
     body: JSON.stringify(requestData),
   };
-  const resp = await fetch(`${api}api=sendInstantNotification`, requestObj);
-  const respJson = await resp.json();
-    if (!resp.ok) {
-      triggerErrorModal(`Error occurred when sending out notification, with message "${respJson.message}".`);
+
+  try {
+    const resp = await fetch(`${api}api=sendInstantNotification`, requestObj);
+    if (resp.ok) return true;
+
+    const respJson = await resp.json();
+    triggerErrorModal(`Error sending notification to participant ${requestData.connectId}: ${respJson.message}.`);
+  } catch (error) {
+    triggerErrorModal(`Error sending notification to participant ${requestData.connectId}: ${error.message}.`);
   }
 
-  return respJson;
+  appState.setState((prevState) => ({
+    ...prevState,
+    handledNotifications: {
+      ...prevState.handledNotifications,
+      [catPtStr]: false,
+    },
+  }));
+
+  return false;
 };
 
 export const biospecimenUsers = async () => {

--- a/src/shared.js
+++ b/src/shared.js
@@ -153,10 +153,9 @@ export const getUserProfile = async (uid) => {
 }
 
 export const sendInstantNotification = async (requestData) => {
-  const catPtStr = `${requestData.category}- ${requestData.connectId}`;
+  const catPtStr = `${requestData.category}-${requestData.connectId}`;
   const isNotificationHandled = appState.getState().handledNotifications?.[catPtStr];
   if (isNotificationHandled) return true;
-
 
   appState.setState((prevState) => ({
     ...prevState,


### PR DESCRIPTION
This PR addresses [issue#1184](https://github.com/episphere/connect/issues/1184). Below are details:
- Uses state manager to track notification handling and block repeated notifications
- Retires `sendClientEmail` function
- Minor code cleanups related to instant notifications