### PR TITLE
Issue#1273 Irving Fix

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -2514,7 +2514,7 @@ export const locationConceptIDToLocationMap = {
         loginSiteName: 'Baylor Scott & White Health',
         email: 'connectbiospecimen@BSWHealth.org'
     },
-    397883980: {
+    [conceptIds.nameToKeyObj.irving]: {
         siteSpecificLocation: 'Irving',
         siteAcronym: 'BSWH',
         siteCode: `${healthProviderAbbrToConceptIdObj.bswh}`,
@@ -2605,6 +2605,7 @@ export const conceptIdToSiteSpecificLocation = {
   436956777: "NTX Biorepository",
   483909879: "North Garland",
   962830330: "Waco - MacArthur",
+  [conceptIds.nameToKeyObj.irving]: "Irving",
   [conceptIds.nameToKeyObj.templeCDM]: "Temple CDM",
   [conceptIds.nameToKeyObj.templeRoney]: "Temple Roney"
 }
@@ -2658,6 +2659,7 @@ export const siteSpecificLocationToConceptId = {
   "NTX Biorepository": 436956777,
   "North Garland": 483909879,
   "Waco - MacArthur": 962830330,
+  "Irving": conceptIds.nameToKeyObj.irving,
   "Temple CDM": conceptIds.nameToKeyObj.templeCDM,
   "Temple Roney": conceptIds.nameToKeyObj.templeRoney
 }
@@ -2751,7 +2753,7 @@ export const keyToLocationObj =
     436956777: "NTX Biorepository",
     483909879: "North Garland",
     962830330: "Waco - MacArthur",
-    397883980: "Irving",
+    [conceptIds.nameToKeyObj.irving]: "Irving",
     [conceptIds.nameToKeyObj.templeCDM]: "Temple CDM",
     [conceptIds.nameToKeyObj.templeRoney]: "Temple Roney",
     111111111: "NIH",


### PR DESCRIPTION
This PR is a follow up to [issue#1273](https://github.com/episphere/connect/issues/1273) and related to the comment:
- https://github.com/episphere/connect/issues/1273#issuecomment-2877330976

Problem / Changes: 
- On the Shipping dashboard, Irving assigned boxes moving to Review Shipping Contents are not able to proceed 
- Added missing references to allow Boxes assigned with "Irving" shipping location to continue in shipping dashboard process

Code Changes:
Added missing Irving property  to `siteSpecificLocationToConceptId` and `conceptIdToSiteSpecificLocation` objects