### PR TITLE
Issue#1209 BSD follow up

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -2782,7 +2782,7 @@ const deprecatedShippingLocations = [
     'HFH Livonia Research Clinic',
     // SFH
     'Sioux Falls Imagenetics',
-    'Sanford South University',
+    'Sioux Falls Sanford Center',
     'Bismarck Medical Center',
     'Fargo South University',
 ];


### PR DESCRIPTION
This pull request is a follow up to [issue#1209 - Removal of Collection and Shipping Locations SFH and HFH](https://github.com/episphere/connect/issues/1209).

Follow up Request: 
- https://github.com/episphere/connect/issues/1209#issuecomment-2891956807
- Remove 'Sioux Falls Sanford Center' from shipping dashboard dropdown selection

Code Changes:
- Replaced 'Sanford South University' with 'Sioux Falls Sanford Center' to filter out 'Sioux Falls Sanford Center' from the data array in the Firestore `siteLocations` response. 'Sanford South University' does not exist in the document so it was replaced. 


<img width="322" alt="Screenshot 2025-05-20 at 10 15 04 AM" src="https://github.com/user-attachments/assets/07027652-6ddb-4c3d-89b4-ffd3557b0812" />
