### PR TITLE
Hotfix Add Henry Ford Main Campus back to Shipping dropdown

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -2778,7 +2778,6 @@ const deprecatedShippingLocations = [
     // HFHS
     'Henry Ford West Bloomfield Hospital',
     'Henry Ford Medical Center- Fairlane',
-    'Henry Ford Main Campus',
     'HFH Livonia Research Clinic',
     // SFH
     'Sioux Falls Imagenetics',


### PR DESCRIPTION
This hotfix is related to [issue#1339](https://github.com/episphere/connect/issues/1339) and related to the previous PR:
- https://github.com/NCI-C4CP/biospecimen/pull/818/files#diff-b1ad84bc7117076c54df7562cdfba01557615bde3c5fe26d1c247789d695ba24R2781

Changes:
- Add back Henry Ford Main Campus that was filtered out from shipping dropdown.

Code Changes
- Remove Henry Ford Main Campus from deprecatedShippingLocations array

![Screenshot 2025-06-02 at 11 36 46 AM](https://github.com/user-attachments/assets/54e1e1e2-d5c2-4a9d-a6a5-f636c523ebba)
