### PR TITLE
Issue#1098 follow up for clear filters button

### DIFF
--- a/src/pages/homeCollection/kitStatusReports.js
+++ b/src/pages/homeCollection/kitStatusReports.js
@@ -274,9 +274,10 @@ function clearFiltersHandler() {
                 if (returnKitTrackingNumInput) returnKitTrackingNumInput.value = '';
                 if (dateReceivedInput) dateReceivedInput.value = '';
                 
-                showAnimation();
                 const status = appState.getState().kitStatus;
                 const kitStatusConceptId = kitStatusSelectionOptions[status]?.conceptId;
+                
+                showAnimation();
                 const response = await getParticipantsByKitStatus(kitStatusConceptId);
                 
                 // Replace table body with no filters applied

--- a/src/pages/homeCollection/kitStatusReports.js
+++ b/src/pages/homeCollection/kitStatusReports.js
@@ -97,7 +97,7 @@ const createColumnHeaders = () => {
 
 /**
  * 
- * Returns rows for the shipped kits table
+ * Returns rows for the Kit Status table
  * @param {Array} reportsData - an array of custom objects with values based on the participant's kit status or only based on unassigned kits (pending assignment kits)
  * @returns {string} - a string of table rows
 */
@@ -276,7 +276,7 @@ function clearFiltersHandler() {
                 
                 const status = appState.getState().kitStatus;
                 const kitStatusConceptId = kitStatusSelectionOptions[status]?.conceptId;
-                
+
                 showAnimation();
                 const response = await getParticipantsByKitStatus(kitStatusConceptId);
                 

--- a/src/pages/homeCollection/kitStatusReports.js
+++ b/src/pages/homeCollection/kitStatusReports.js
@@ -276,9 +276,7 @@ function clearFiltersHandler() {
                 
                 showAnimation();
                 const status = appState.getState().kitStatus;
-                console.log("status", status);
                 const kitStatusConceptId = kitStatusSelectionOptions[status]?.conceptId;
-                console.log("🚀 ~ clearButton.addEventListener ~ kitStatusConceptId:", kitStatusConceptId)
                 const response = await getParticipantsByKitStatus(kitStatusConceptId);
                 
                 // Replace table body with no filters applied

--- a/src/pages/homeCollection/kitStatusReports.js
+++ b/src/pages/homeCollection/kitStatusReports.js
@@ -98,7 +98,7 @@ const createColumnHeaders = () => {
 /**
  * 
  * Returns rows for the shipped kits table
- * @param {Array} reportsData - an array of custom objects with values from participants and kitAssembly collection that have a shipped kit status
+ * @param {Array} reportsData - an array of custom objects with values based on the participant's kit status or only based on unassigned kits (pending assignment kits)
  * @returns {string} - a string of table rows
 */
 const createColumnRows = (reportsData) => {

--- a/src/pages/homeCollection/kitStatusReports.js
+++ b/src/pages/homeCollection/kitStatusReports.js
@@ -261,9 +261,9 @@ function clearFiltersHandler() {
                 const dateReceivedInput = document.getElementById("dateReceived");
 
                 const areAllInputsEmpty = 
-                    collectionIdInput.value === '' && 
-                    connectIdInput.value === '' && 
-                    returnKitTrackingNumInput.value === '' && 
+                    collectionIdInput.value.trim() === '' && 
+                    connectIdInput.value.trim() === '' && 
+                    returnKitTrackingNumInput.value.trim() === '' && 
                     dateReceivedInput.value === '';
 
                 if (areAllInputsEmpty) return; // Prevent an API call if all inputs are already empty.

--- a/src/pages/homeCollection/kitStatusReports.js
+++ b/src/pages/homeCollection/kitStatusReports.js
@@ -205,7 +205,7 @@ const createKitStatusFilterSection = () => {
                     <label for="dateReceived" class="form-label">Date Received</label>
                     <input type="date" class="form-control" id="dateReceived" max="${getCurrentDate()}" style="margin-bottom: 1rem;">
 
-                    <button class="btn btn-primary mt-2" id="filterKitsButton">Filter Kits</button>
+                    <button class="btn btn-primary mt-2" id="filterKitsButton">Apply Filters</button>
                     <button class="btn btn-secondary mt-2" id="clearFiltersButton">Clear Filters</button style="margin-bottom: 1rem;">
                 </div>
         `;
@@ -234,7 +234,7 @@ function filterKitsHandler () {
                 const response = await getParticipantsByKitStatus(kitStatusConceptId, filters);
                 
                 // Re-render the table with the new, filtered data
-                const newTableBody = createColumnRows(response.data, status);
+                const newTableBody = createColumnRows(response.data);
                 document.querySelector("#kitStatusReportsTable tbody").innerHTML = newTableBody;
             } catch (error) {
                 console.error("Error filtering kits:", error);
@@ -246,21 +246,49 @@ function filterKitsHandler () {
     }
 };
 
+/**
+ * Clears the input fields, re-fetches the received kit status reports data, and updates the table
+*/
 function clearFiltersHandler() { 
     const clearButton = document.getElementById("clearFiltersButton");
 
     if (clearButton) {
-        clearButton.addEventListener("click", () => {
-            // Reset all input fields to empty
-            const collectionIdInput = document.getElementById("collectionId");
-            const connectIdInput = document.getElementById("connectId");
-            const returnKitTrackingNumInput = document.getElementById("returnKitTrackingNum");
-            const dateReceivedInput = document.getElementById("dateReceived");
+        clearButton.addEventListener("click", async () => {
+            try {
+                const collectionIdInput = document.getElementById("collectionId");
+                const connectIdInput = document.getElementById("connectId");
+                const returnKitTrackingNumInput = document.getElementById("returnKitTrackingNum");
+                const dateReceivedInput = document.getElementById("dateReceived");
 
-            if (collectionIdInput) collectionIdInput.value = '';
-            if (connectIdInput) connectIdInput.value = '';
-            if (returnKitTrackingNumInput) returnKitTrackingNumInput.value = '';
-            if (dateReceivedInput) dateReceivedInput.value = '';
+                const areAllInputsEmpty = 
+                    collectionIdInput.value === '' && 
+                    connectIdInput.value === '' && 
+                    returnKitTrackingNumInput.value === '' && 
+                    dateReceivedInput.value === '';
+
+                if (areAllInputsEmpty) return; // Prevent an API call if all inputs are already empty.
+
+                // clear inputs
+                if (collectionIdInput) collectionIdInput.value = '';
+                if (connectIdInput) connectIdInput.value = '';
+                if (returnKitTrackingNumInput) returnKitTrackingNumInput.value = '';
+                if (dateReceivedInput) dateReceivedInput.value = '';
+                
+                showAnimation();
+                const status = appState.getState().kitStatus;
+                console.log("status", status);
+                const kitStatusConceptId = kitStatusSelectionOptions[status]?.conceptId;
+                console.log("🚀 ~ clearButton.addEventListener ~ kitStatusConceptId:", kitStatusConceptId)
+                const response = await getParticipantsByKitStatus(kitStatusConceptId);
+                
+                // Replace table body with no filters applied
+                const newTableBody = createColumnRows(response.data);
+                document.querySelector("#kitStatusReportsTable tbody").innerHTML = newTableBody;
+            } catch (error) {
+                console.error("Error clearing filters:", error);
+            } finally {
+                hideAnimation();
+            }
         });
     }
 }

--- a/src/pages/homeCollection/participantSelectionHeaders.js
+++ b/src/pages/homeCollection/participantSelectionHeaders.js
@@ -22,7 +22,7 @@ export const renderKitStatusList = () => {
                     <label for="kitStatusSelection" class="col-form-label">Kit Status</label>
                     <select required class="col form-control kitStatusSelectionDropdown" id="kitStatusSelection">
                         <option id="select-dashboard" value="" >-- Select dashboard --</option>
-                        <option id="select-pending" value="pending" >Pending</option>
+                        <option id="select-pending" value="pending" >Pending Assignment</option>
                         <option id="select-assigned" value="assigned" >Assigned</option>
                         <option id="select-shipped" value="shipped">Shipped</option>
                         <option id="select-received" value="received">Received</option>


### PR DESCRIPTION
This PR is related to issue#1098 and the following links:
- https://github.com/episphere/connect/issues/1098
- https://github.com/NCI-C4CP/biospecimen/pull/837
- https://github.com/NCI-C4CP/connectFaas/pull/793
- https://github.com/episphere/connect/issues/1098#issuecomment-2980997345

Request Changes (from comment):
- Have the 'Clear Filters' button get data with no filters applied and re-create table 
- Additional outside of comment, renaming the 'Pending' option to 'Pending Assignment' and renaming 'Filter Kits' button to 'Apply Filters'


Code Changes:
- Updated `clearFiltersHandler` function to pull data with no filters applied and re-create table
- Renamed 'Kit Filters' button and 'Pending' option
- Updated JSdocs comment for `createColumnRows` function and remove 'status' argument from one of the `createColumnRows` function calls
