### PR TITLE
issue#1355 SFH collection location update

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -2797,7 +2797,8 @@ export const deprecatedResearchCollectionLocations = [
     // SFH
     'Sioux Falls Imagenetics', 
     'Bismarck Medical Center', 
-    'Fargo South University'
+    'Fargo South University',
+    'Sioux Falls Sanford Center'
 ]
 
 export const verificationConversion = {


### PR DESCRIPTION
This PR is related to [issue#1355](https://github.com/episphere/connect/issues/1355).

Request:
- Remove 'Sioux Falls Sanford Center' option from Sandford's research collection dropdown list

Code Changes: 
- Added 'Sioux Falls Sanford Center' to deprecatedResearchCollectionLocations array.