### PR TITLE
1370 Front-end Changes

### DIFF
--- a/src/pages/homeCollection/kitShipment.js
+++ b/src/pages/homeCollection/kitShipment.js
@@ -45,7 +45,7 @@ const verifyScannedCode = async () => {
   if (scannedCodeInput) {
     scannedCodeInput.addEventListener("change", async () => {
       showAnimation();
-      const isScannedCodeValid = await checkScannedCodeValid(scannedCodeInput.value)
+      const isScannedCodeValid = await checkScannedCodeValid(scannedCodeInput.value);
       isScannedCodeValid.data?.valid ? confirmPickupTemplate(isScannedCodeValid.data?.uniqueKitID) : tryAgainTemplate();
       hideAnimation();
     });
@@ -140,7 +140,11 @@ const setShippedResponse = async (data) => {
     };
     
     await sendInstantNotification(requestData);
+  } else if (returnedPtInfo.status) {
+    triggerErrorModal(`Error in shipping: ${returnedPtInfo.status}`);
   } else {
+    // Leave this console log in; it's useful for debugging in the event of reported errors
+    console.log('returnedPtInfo', returnedPtInfo);
     triggerErrorModal('Error in shipping: Please check the tracking number.');
   }
   

--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -290,7 +290,11 @@ const storePackageReceipt = async (data) => {
     openModal();
     displayInvalidCollectionDateModal(modalHeaderEl, modalBodyEl, returnedPtInfo.status);
     appState.setState({ lastRequestedCollectionDateTimeStamp: data[conceptIds.collectionDateTimeStamp] });
+  } else if (returnedPtInfo.status) {
+    triggerErrorModal(`Error during kit receipt. ${returnedPtInfo.status}`);
   } else {
+    // Leave this console log in; it's useful for debugging
+    console.log('returnedPtInfo', returnedPtInfo);
     triggerErrorModal("Error during kit receipt. Please check the tracking number and other fields.");
   }
 };


### PR DESCRIPTION
Updates biospecimen to have better messaging for the user for the errors returned by connectFaas in the cases of deceased or withdrawn participants. For [1370](https://github.com/episphere/connect/issues/1370).

Changes:

kitShipment.js:
* Missing semicolon added at end of line
* setShippedResponse: if returnedPtInfo.status exists and is not true, displays it as a message for the end user.

kitsReceipt.js:
* storePackageReceipt:  if returnedPtInfo.status exists and is not true, displays it as a message for the end user.

assignKits.js:
* clearParticipantFromQueue helper function added, as this code is reused in multiple places
* Logic moved out of processConfirmedAssignment back into confirmAssignment for better handling in the event of errors on the back end
* confirmAssignment error messaging updated and can now handle removeFromQueue flags passed back when assigning kits to participants (used in new functionality for deceased and withdrawn participants) to remove participants from the list on the front end without requiring a page refresh.
* clickConfirmButton received similar changes to confirmAssignment; updated to use clearParticipantFromQueue, able to process removeFromQueue flag returned from backend for the same behavior as confirmAssignment. Try/catch wrapping also added