### PR TITLE
Missed removing ACD tube from clinical tubes in previous PR; removed.

### DIFF
--- a/src/tubeValidation.js
+++ b/src/tubeValidation.js
@@ -364,7 +364,7 @@ export const workflows = {
         tube0004,
         tube0014,
         tube0024,
-        tube0005,
+        // tube0005, // ACD tubes removed March 1, 2024
         tube0060,
         tube0006,
         tube0008


### PR DESCRIPTION
Followup to [1341](https://github.com/episphere/connect/issues/1341#issuecomment-3185313187) comments.