### PR TITLE
1310 implementation

### DIFF
--- a/src/pages/homeCollection/kitStatusReports.js
+++ b/src/pages/homeCollection/kitStatusReports.js
@@ -79,10 +79,10 @@ const createTableContent = (reportsData) => {
 
 const createKitStatusTable = (reportsData) => {
     return `
-            <div class="sticky-header" style="overflow:auto;">
+            <div class="sticky-header" style="overflow:auto; max-height: 75vh">
                 <table class="table table-bordered" id="kitStatusReportsTable" style="margin-bottom:1rem; 
                     position:relative; border-collapse:collapse;">
-                    <thead> 
+                    <thead class="sticky-top top-0"> 
                         <tr style="top: 0; position: sticky;">
                             ${createColumnHeaders()}
                         </tr>


### PR DESCRIPTION
Added individual scrollbar to kit status report table to allow for pinned header and scrolling of table contents per [1310](https://github.com/episphere/connect/issues/1310).

Changes:
kitStatusReports.js:
* max-height added to table wrapping div so that overflow will create scrollbar inside table instead of extending table height to match the contents.
* sticky-top and top-0 classes added to table header to ensure table header remains fixed at the top as the user scrolls up and down the page.

Adding sticky-top and top-0 alone was insufficient to ensure this behavior; I was only able to get it working by placing the overflow scrollbar on the table div itself. Erin and Kathleen have reviewed footage of this fix on my screen and are satisfied with the behavior.