### PR TITLE
1316/1388 Fix

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1429,7 +1429,7 @@ const collectionSubmission = async (participantData, biospecimenData, continueTo
             focus = false;
         }
 
-        if(hasError) return; // Do not set scanned ID if the tube has an error (further hardening for issues 1316/1388)
+        if (hasError) return; // Do not set scanned ID if the tube has an error (further hardening for issues 1316/1388)
 
         if (tubeConceptId && input.required) biospecimenData[tubeConceptId][conceptIds.collection.tube.scannedId] = `${masterID} ${tubeID}`.trim();
     });
@@ -1445,11 +1445,11 @@ const collectionSubmission = async (participantData, biospecimenData, continueTo
         }
 
         biospecimenData[tube.id][conceptIds.collection.tube.isCollected] = tube.checked ? conceptIds.yes : conceptIds.no;
-        if(!tube.checked) {
+        if (!tube.checked) {
             // If the tube has been unchecked, ensure the value is cleared
             // (This solves issues 1316/1388 where tubes which were mis-scanned, unchecked
             // and then saved were saving their IDs and appearing in the shipping manifest)
-            if(biospecimenData[tube.id][conceptIds.collection.tube.scannedId]) {
+            if (biospecimenData[tube.id][conceptIds.collection.tube.scannedId]) {
                 delete biospecimenData[tube.id][conceptIds.collection.tube.scannedId];
             }
         }

--- a/src/events.js
+++ b/src/events.js
@@ -1429,6 +1429,8 @@ const collectionSubmission = async (participantData, biospecimenData, continueTo
             focus = false;
         }
 
+        if(hasError) return; // Do not set scanned ID if the tube has an error (further hardening for issues 1316/1388)
+
         if (tubeConceptId && input.required) biospecimenData[tubeConceptId][conceptIds.collection.tube.scannedId] = `${masterID} ${tubeID}`.trim();
     });
 
@@ -1443,6 +1445,14 @@ const collectionSubmission = async (participantData, biospecimenData, continueTo
         }
 
         biospecimenData[tube.id][conceptIds.collection.tube.isCollected] = tube.checked ? conceptIds.yes : conceptIds.no;
+        if(!tube.checked) {
+            // If the tube has been unchecked, ensure the value is cleared
+            // (This solves issues 1316/1388 where tubes which were mis-scanned, unchecked
+            // and then saved were saving their IDs and appearing in the shipping manifest)
+            if(biospecimenData[tube.id][conceptIds.collection.tube.scannedId]) {
+                delete biospecimenData[tube.id][conceptIds.collection.tube.scannedId];
+            }
+        }
 
         const reason = document.getElementById(tube.id + 'Reason');
         const deviated = document.getElementById(tube.id + 'Deviated');

--- a/src/pages/shipping.js
+++ b/src/pages/shipping.js
@@ -222,7 +222,7 @@ const populateAvailableCollectionsList = async (availableCollectionsObj, specime
 
             const currDeleteButton = rowEle.cells[1].getElementsByClassName("delButton")[0];
 
-            //This should remove the entrire bag
+            //This should remove the entire bag
             currDeleteButton.addEventListener("click", async e => {
                 showAnimation();
                 const index = e.target.parentNode.parentNode.rowIndex;
@@ -876,7 +876,7 @@ export const generateShippingManifest = async (boxIdArray, userName, isTempMonit
     navBarBtn.classList.add('active');
     document.getElementById('contentBody').innerHTML = renderShippingManifestTemplate(boxIdArray, isTempMonitorIncluded);
     
-    populateShippingManifestHeader(userName, siteAcronym, currShippingLocationNumber); // populate shipping header via site specfiic location selected from shipping page
+    populateShippingManifestHeader(userName, siteAcronym, currShippingLocationNumber); // populate shipping header via site specific location selected from shipping page
     populateShippingManifestTable(boxIdAndBagsObjToDisplay);
     addEventNavBarShipment("navBarShippingDash", userName);
     addEventShipPrintManifest('printBox');

--- a/src/shared.js
+++ b/src/shared.js
@@ -1277,7 +1277,7 @@ export const findReplacementTubeLabels = (specimensList) => {
  */
 const arrangeFetchedTubes = (specimen, isPartiallyBoxed) => {
     const usableTubes = {};
-    
+
     const collectionId = specimen[conceptIds.collection.id];
     if (!collectionId) return;
     const bloodUrineCollection = `${collectionId} 0008`;
@@ -1402,6 +1402,13 @@ const removeUnusableTubes = (specimen) => {
         }
 
         if (tube[conceptIds.collection.tube.isMissing] === conceptIds.yes) {
+            delete specimen[tubeKey];
+            continue;
+        }
+
+        if (tube[conceptIds.collection.tube.isCollected] === conceptIds.no) {
+            // If the tube is not even marked as collected, it should also be removed as unusable
+            // (Issues 1388 and 1316)
             delete specimen[tubeKey];
             continue;
         }


### PR DESCRIPTION
Identified the cause of tickets [1316](https://github.com/episphere/connect/issues/1316) and [1388](https://github.com/episphere/connect/issues/1388). The issue was that, when a tube on the collection page was checked, scanned with the wrong tube ID, and then unchecked before the page was saved, the tube would be saved with the incorrect ID. The shipping manifest page checks that that value has been set and actually does not check that the tube is marked as collected. When user error caused a tube ID to be incorrectly scanned to one location, unchecked, and then correctly scanned to the next location, this was causing duplicate tube IDs to appear on the shipping manifest.

Code hardened in the following ways to prevent this:

shared.js:
* removeUnusableTubes updated to remove tubes which have not been marked as collected, as tubes which are not collected are in fact unusable.

events.js:
* collectionSubmission code updated so that the scanned ID will not be saved for tubes whose barcodes have errors.
* Logic further down also added so that if a tube is not checked but has a barcode, that barcode will be cleared.

Also updated some typos in shipping.js which are immaterial but were annoying me.