### PR TITLE
Issue#1352 follow up 1

### DIFF
--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -277,9 +277,11 @@ export const conceptIds = {
 
     clinicalDashboard: {
         bloodCollected: 534041351,
-        bloodCollectedTime: 398645039,
+        bloodCollectedTime: 398645039, // date and timestamp saved upon specimen link
+        bloodCollectedEMRTime: 982213346, // date and timestamp sent from EMR to NCI via API
         urineCollected: 210921343,
-        urineCollectedTime: 541311218
+        urineCollectedTime: 541311218, // date and timestamp saved upon specimen link
+        urineCollectedEMRTime: 139245758 // date and timestamp sent from EMR to NCI via API
     },
 
     anySpecimenCollected: 316824786,

--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -605,12 +605,12 @@ const getHomeMouthwashKitData = (data, homeMouthwashCollectionId) => {
             mouthwashCollectionId: homeMouthwashCollectionId,
             mouthwashTime: kitStatusReceivedDate
         }
-    } else {
-        return {
+    }
+    
+    return {
             mouthwashCollectionId: undefined,
             mouthwashTime: undefined
         };
-    }
 };
 
 /**

--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -190,10 +190,10 @@ const participantStatus = (data, collections, isCheckedIn, homeMouthwashCollecti
     const researchMouthwashData = {
         mouthwashCollectionId: mouthwashCollection,
         mouthwashTime: mouthwashTime
-    }
+    };
 
-    const homeMouthwashKitData = getHomeMouthwashKitData(data, homeMouthwashCollectionId)
-    const oldestMouthwashData = getOldestMouthwashData(researchMouthwashData, homeMouthwashKitData)
+    const homeMouthwashKitData = getHomeMouthwashKitData(data, homeMouthwashCollectionId);
+    const oldestMouthwashData = getOldestMouthwashData(researchMouthwashData, homeMouthwashKitData);
 
     const baselineClinicalBloodCollectionEMRTime = data[conceptIds.collectionDetails]
         ?.[conceptIds.baseline.visitId]
@@ -213,7 +213,7 @@ const participantStatus = (data, collections, isCheckedIn, homeMouthwashCollecti
         isMouthwashCollected: data[conceptIds.baseline.mouthwashCollected],
         mouthwashTime: oldestMouthwashData?.mouthwashTime,
         mouthwashCollectionId: oldestMouthwashData?.mouthwashCollectionId,
-    }
+    };
 
     return `
         <div class="row">
@@ -659,7 +659,10 @@ const getOldestMouthwashData = (researchMouthwashData, homeMouthwashKitData) => 
 
     // Determine if and which timestamps exist
     if (!researchTimeString && !homeTimeString) {
-        return { mouthwashCollectionId: undefined, mouthwashTime: undefined };
+        return { 
+            mouthwashCollectionId: undefined,
+            mouthwashTime: undefined
+        };
     }
 
     if (!researchTimeString && homeTimeString) {

--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -193,11 +193,7 @@ const participantStatus = (data, collections, isCheckedIn, homeMouthwashCollecti
     }
 
     const homeMouthwashKitData = getHomeMouthwashKitData(data, homeMouthwashCollectionId)
-    console.log("🚀 ~ participantStatus ~ homeMouthwashKitStatusData:", homeMouthwashKitData)
-    
     const oldestMouthwashData = getOldestMouthwashData(researchMouthwashData, homeMouthwashKitData)
-    console.log("🚀 ~ participantStatus ~ oldestMouthwashData:", oldestMouthwashData)
-    
 
     const baselineClinicalBloodCollectionEMRTime = data[conceptIds.collectionDetails]
         ?.[conceptIds.baseline.visitId]
@@ -527,7 +523,7 @@ const participantStatus = (data, collections, isCheckedIn, homeMouthwashCollecti
         </div>
     `;
     
-}
+};
 
 /**
  * @param {string} baselineType - "blood", "urine", or "mouthwash"
@@ -658,28 +654,20 @@ const getHomeMouthwashCollectionId = (participantData, biospecimenCollections) =
  * @returns {object} An object with the oldest mouthwash collection id and oldest date timestamp or an object with undefined values
  */
 const getOldestMouthwashData = (researchMouthwashData, homeMouthwashKitData) => {
-    console.log("🚀 ~ getOldestMouthwashData ~ researchMouthwashData:", researchMouthwashData)
-    console.log("🚀 ~ getOldestMouthwashData ~ homeMouthwashKitData:", homeMouthwashKitData)
-    
     const researchTimeString = researchMouthwashData?.mouthwashTime;
     const homeTimeString = homeMouthwashKitData?.mouthwashTime;
-    console.log("🚀 ~ getOldestMouthwashData ~ researchTime:", researchTimeString)
-    console.log("🚀 ~ getOldestMouthwashData ~ homeTimeString:", homeTimeString)
 
     // Determine if and which timestamps exist
     if (!researchTimeString && !homeTimeString) {
-        console.log("No mouthwash collections data found!", researchMouthwashData, homeMouthwashKitData)
         return { mouthwashCollectionId: undefined, mouthwashTime: undefined };
     }
 
     if (!researchTimeString && homeTimeString) {
-        console.log("Only homeMouthwashKitData found", homeMouthwashKitData)
-        return homeMouthwashKitData
+        return homeMouthwashKitData;
     }
 
     if (researchTimeString && !homeTimeString) {
-        console.log("Only researchMouthwashData found", researchMouthwashData)
-        return researchMouthwashData
+        return researchMouthwashData;
     }
     
     // Convert timestamps to Date objects for comparison and to check if they are valid dates
@@ -691,18 +679,19 @@ const getOldestMouthwashData = (researchMouthwashData, homeMouthwashKitData) => 
     const isHomeDateInvalid = isNaN(homeMouthwashDate.getTime());
 
     if (isResearchDateInvalid && isHomeDateInvalid) {
-        console.log("Both mouthwash collection dates are invalid!", researchMouthwashData, homeMouthwashKitData)
-        return { mouthwashCollectionId: undefined, mouthwashTime: undefined };
+        return { 
+            mouthwashCollectionId: undefined,
+            mouthwashTime: undefined 
+        };
     }
 
     if (isResearchDateInvalid) {
-        console.log("Only homeMouthwashKitData is valid", homeMouthwashKitData)
         return homeMouthwashKitData;
     }
 
     if (isHomeDateInvalid) {
-        console.log("Only researchMouthwashData is valid", researchMouthwashData)
         return researchMouthwashData;
     }
+
     return researchMouthwashDate <= homeMouthwashDate ? researchMouthwashData : homeMouthwashKitData;
 };

--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -587,7 +587,7 @@ const getBaselineDisplayStatus = (baselineType, baselineSampleStatusInfo) => {
  * Determines if participant has a baseline home mouthwash kit and a home mouthwash kit received date/time
  * @param {object} data - The participant data object from participants collection
  * @param {string} homeMouthwashCollectionId - The collection ID of the home mouthwash collection if found
- * @returns {object} An object with the received date/time and home mouthwash collection if found, otherwise undefined
+ * @returns {object} An object with the received date/time and home mouthwash collection if found, otherwise null values
  */
 const getHomeMouthwashKitData = (data, homeMouthwashCollectionId) => {
     const isKitTypeHomeMouthwash = data[conceptIds.collectionDetails]
@@ -608,8 +608,8 @@ const getHomeMouthwashKitData = (data, homeMouthwashCollectionId) => {
     }
     
     return {
-            mouthwashCollectionId: undefined,
-            mouthwashTime: undefined
+            mouthwashCollectionId: null,
+            mouthwashTime: null
         };
 };
 
@@ -648,10 +648,10 @@ const getHomeMouthwashCollectionId = (participantData, biospecimenCollections) =
 
 /**
  * Checks the research and home mouthwash timestamps if they exist and are valid dates.
- * Then returns an object of either home mouthwash values, research mouthwash values, or undefined values
+ * Then returns an object of either home mouthwash values, research mouthwash values, or null values
  * @param {object} researchMouthwashData Ex. { mouthwashCollectionId: "CXA835553", mouthwashTime: "2025-09-08T16:39:07.949Z" } 
  * @param {object} homeMouthwashKitData Ex. { mouthwashCollectionId: "CHA380229", mouthwashTime: "2025-09-11T00:00:00.000Z" }
- * @returns {object} An object with the oldest mouthwash collection id and oldest date timestamp or an object with undefined values
+ * @returns {object} An object with the oldest mouthwash collection id and oldest date timestamp or an object with null values
  */
 const getOldestMouthwashData = (researchMouthwashData, homeMouthwashKitData) => {
     const researchTimeString = researchMouthwashData?.mouthwashTime;
@@ -660,8 +660,8 @@ const getOldestMouthwashData = (researchMouthwashData, homeMouthwashKitData) => 
     // Determine if and which timestamps exist
     if (!researchTimeString && !homeTimeString) {
         return { 
-            mouthwashCollectionId: undefined,
-            mouthwashTime: undefined
+            mouthwashCollectionId: null,
+            mouthwashTime: null
         };
     }
 
@@ -683,8 +683,8 @@ const getOldestMouthwashData = (researchMouthwashData, homeMouthwashKitData) => 
 
     if (isResearchDateInvalid && isHomeDateInvalid) {
         return { 
-            mouthwashCollectionId: undefined,
-            mouthwashTime: undefined 
+            mouthwashCollectionId: null,
+            mouthwashTime: null 
         };
     }
 

--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -606,7 +606,7 @@ const getHomeMouthwashKitData = (data, homeMouthwashCollectionId) => {
             mouthwashTime: kitStatusReceivedDate
         }
     } else {
-        return  {
+        return {
             mouthwashCollectionId: undefined,
             mouthwashTime: undefined
         };


### PR DESCRIPTION
This pull request is a follow up to [issue#1352](https://github.com/episphere/connect/issues/1352)

Issue Comment (dev testing)
- https://github.com/episphere/connect/issues/1352#issuecomment-3325021748

Changes:
- Added logic to determine the oldest baseline mouthwash statuses data (collected id and timestamp) and display it on the research dashboard's checkin/checkout page 
- Updated the reference for Clinical Blood and Urine's Collection time to site's EMR time sent to NCI via API

Code Changes:
- Created new function `getOldestMouthwashData ` to compare mouthwash timestamps and return oldest mouthwash timestamp and its related collection ID
- Added `bloodCollectedEMRTime`  and `urineCollectedEMRTime` concept Ids to `fieldToConceptIdMapping.js` file
- Referenced `bloodCollectedEMRTime`  and `urineCollectedEMRTime` to `baselineClinicalBloodCollectionEMRTime` and `baselineClinicalUrineCollectionEMRTime` variables
- Updated JSDocs