### PR TITLE
Issue#1352 follow up 3

### DIFF
--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -539,10 +539,8 @@ const getBaselineDisplayStatus = (baselineType, baselineSampleStatusInfo) => {
     const { 
         bloodTime, 
         isBloodCollected,
-        bloodCollection,
         urineTime, 
         isUrineCollected,
-        urineCollection, 
         mouthwashTime, 
         isMouthwashCollected 
     } = baselineSampleStatusInfo;
@@ -561,7 +559,7 @@ const getBaselineDisplayStatus = (baselineType, baselineSampleStatusInfo) => {
         collectionTime = mouthwashTime;
     }
 
-    if (isCollected === conceptIds.yes && collectionTime) {
+    if (isCollected === conceptIds.yes) { // Note: Collection time is only needed for "In Progress" status
         return {
             "htmlIcon": `<span class="full-width"><i class="fas fa-2x fa-check"></i></span>`,
             "text": "Collected"


### PR DESCRIPTION
This PR is a follow up to [issue#1352](https://github.com/episphere/connect/issues/1352)

**Dev testing:**
While testing Clinical Collections that were finalized but didn't have an EMR time stamp for blood and urine collections were displaying as Not Collected. 

Code Changes:
Remove collection time dependency logic that would return the green check mark and Collected text.

Image from testing:
<img width="700" height="457" alt="Screenshot 2025-09-25 at 11 55 10 AM" src="https://github.com/user-attachments/assets/bf7d52e8-8fb5-4868-87b3-a5555c6d48ff" />

Image with Changes:
<img width="700" height="457" alt="Screenshot 2025-09-25 at 11 48 04 AM" src="https://github.com/user-attachments/assets/ac4c65ca-7d46-4146-bb78-ce014e57b28f" />